### PR TITLE
Add type hinting to program code

### DIFF
--- a/source/stylist/__main__.py
+++ b/source/stylist/__main__.py
@@ -12,15 +12,17 @@ import argparse
 import logging
 import os.path
 import sys
+from typing import Any, Iterable, List, Mapping
 
 from stylist.engine import CheckEngine
+from stylist.issue import Issue
 from stylist.source import CPreProcessor, CSource, FortranPreProcessor, \
                            FortranSource, PFUnitProcessor, \
                            SourceFactory
 from stylist.style import LFRicStyle
 
 
-def parse_cli():
+def parse_cli() -> dict:
     '''
     Parse the command line. Returns a dictionary of arguments.
     '''
@@ -50,7 +52,7 @@ _PREPROCESSOR_MAP = {'cpp': CPreProcessor,
                      'pfp': PFUnitProcessor}
 
 
-def _add_extensions(additional_extensions):
+def _add_extensions(additional_extensions: Iterable[str]) -> None:
     # This application always expects pFUnit source to be present so it adds
     # a rule for that.
     #
@@ -80,7 +82,7 @@ def _add_extensions(additional_extensions):
                                     *preproc_objects)
 
 
-def process(arguments):
+def process(arguments: Mapping[str, Any]) -> List[Issue]:
     '''
     Examines files for style compliance.
 
@@ -115,6 +117,13 @@ def process(arguments):
         else:  # Is a file
             issues.extend(engine.check(filename))
 
+    return issues
+
+
+def main() -> None:
+    '''Main entry point.'''
+    issues = process(parse_cli())
+
     for issue in issues:
         print(str(issue), file=sys.stderr)
     if (len(issues) > 0) or arguments.verbose:
@@ -122,8 +131,5 @@ def process(arguments):
 
     if issues:
         sys.exit(1)
-
-
-def main():
-    '''Main entry point.'''
-    return process(parse_cli())
+    else:
+        sys.exit(0)

--- a/source/stylist/engine.py
+++ b/source/stylist/engine.py
@@ -8,7 +8,7 @@
 Core of the Fortran style checking tool.
 '''
 import logging
-from typing import List
+from typing import Sequence
 
 import stylist.issue
 import stylist.source
@@ -21,7 +21,7 @@ class CheckEngine(object):
     Manages the checking of Fortran source files against style lists.
     '''
 
-    def __init__(self, styles: List[stylist.style.Style]):
+    def __init__(self, styles: Sequence[stylist.style.Style]):
         '''
         Constructs a CheckEngine object from list of style lists.
 
@@ -29,7 +29,7 @@ class CheckEngine(object):
         '''
         self._styles = styles
 
-    def check(self, source_filename: str) -> List[stylist.issue.Issue]:
+    def check(self, source_filename: str) -> Sequence[stylist.issue.Issue]:
         '''
         Passes the eyes of all registered style lists over the source file.
 

--- a/source/stylist/engine.py
+++ b/source/stylist/engine.py
@@ -8,8 +8,11 @@
 Core of the Fortran style checking tool.
 '''
 import logging
+from typing import List
 
+import stylist.issue
 import stylist.source
+import stylist.style
 
 
 class CheckEngine(object):
@@ -18,7 +21,7 @@ class CheckEngine(object):
     Manages the checking of Fortran source files against style lists.
     '''
 
-    def __init__(self, styles):
+    def __init__(self, styles: List[stylist.style.Style]):
         '''
         Constructs a CheckEngine object from list of style lists.
 
@@ -26,7 +29,7 @@ class CheckEngine(object):
         '''
         self._styles = styles
 
-    def check(self, source_filename):
+    def check(self, source_filename: str) -> List[stylist.issue.Issue]:
         '''
         Passes the eyes of all registered style lists over the source file.
 

--- a/source/stylist/fortran.py
+++ b/source/stylist/fortran.py
@@ -10,7 +10,7 @@ Rules relating to Fortran source.
 
 from typing import List
 
-import fparser
+import fparser  # type: ignore
 
 from stylist.issue import Issue
 from stylist.rule import Rule, FortranRule

--- a/source/stylist/fortran.py
+++ b/source/stylist/fortran.py
@@ -8,9 +8,13 @@
 Rules relating to Fortran source.
 '''
 
+from typing import List
+
 import fparser
+
 from stylist.issue import Issue
 from stylist.rule import Rule, FortranRule
+from stylist.source import FortranSource
 
 
 class FortranCharacterset(Rule):
@@ -29,7 +33,7 @@ class FortranCharacterset(Rule):
     _NEWLINE = '\n'
     _QUOTE = '"'
 
-    def examine(self, subject):
+    def examine(self, subject: FortranSource) -> List[Issue]:
         # pylint: disable=too-many-branches
         '''
         Examines the source code for none Fortran characters.
@@ -85,7 +89,7 @@ class MissingImplicit(FortranRule):
     Catches cases where code blocks which could have an "implicit" statement
     don't.
     '''
-    def __init__(self, default):
+    def __init__(self, default: str):
         '''
         Constructor taking a default implication.
 
@@ -108,7 +112,7 @@ class MissingImplicit(FortranRule):
                    fparser.two.Fortran2003.Subroutine_Stmt: 'Subroutine',
                    fparser.two.Fortran2003.Function_Stmt: 'Function'}
 
-    def examine_fortran(self, subject):
+    def examine_fortran(self, subject: FortranSource) -> List[Issue]:
         issues = []
 
         scope_units = subject.path('Program_Unit')
@@ -139,7 +143,7 @@ class MissingOnly(FortranRule):
     '''
     Catches cases where a "use" statement is present but has no "only" claus.
     '''
-    def __init__(self, ignore=[]):
+    def __init__(self, ignore: List[str] = []):
         '''
         Constructs a "MissingOnly" rule object taking a list of exception
         modules which are not required to have an "only" clause.
@@ -147,7 +151,7 @@ class MissingOnly(FortranRule):
         assert isinstance(ignore, list)
         self._ignore = ignore
 
-    def examine_fortran(self, subject):
+    def examine_fortran(self, subject: FortranSource) -> List[Issue]:
         issues = []
 
         for statement in subject.find_all(fparser.two.Fortran2003.Use_Stmt):

--- a/source/stylist/issue.py
+++ b/source/stylist/issue.py
@@ -14,12 +14,15 @@ class Issue(object):
     '''
     Holds details pertaining to an issue with the source.
     '''
-    def __init__(self, description, line=None, filename=None):
+    def __init__(self,
+                 description: str,
+                 line: int = None,
+                 filename: str = None):
         self._filename = filename
         self._line = line
         self._description = description
 
-    def __str__(self):
+    def __str__(self) -> str:
         string = ''
         if self._filename:
             string += '{filename}: '
@@ -30,7 +33,7 @@ class Issue(object):
                              line=self._line,
                              description=self._description)
 
-    def set_filename(self, filename):
+    def set_filename(self, filename: str) -> None:
         '''
         Attaches a filename to this issue.
         '''

--- a/source/stylist/rule.py
+++ b/source/stylist/rule.py
@@ -11,9 +11,10 @@ A collection of style rules.
 from abc import ABCMeta, abstractmethod
 import logging
 import re
+from typing import List
 
 from stylist.issue import Issue
-from stylist.source import FortranSource
+from stylist.source import FortranSource, SourceText
 
 
 class Rule(object, metaclass=ABCMeta):
@@ -22,7 +23,7 @@ class Rule(object, metaclass=ABCMeta):
     Abstract parent of all rules.
     '''
     @abstractmethod
-    def examine(self, subject):
+    def examine(self, subject) -> List[Issue]:
         '''
         Examines the provided source code object for an issue.
 
@@ -40,7 +41,7 @@ class TrailingWhitespace(Rule):
     '''
     _TRAILING_SPACE_PATTERN = re.compile(r'\s+$')
 
-    def examine(self, subject):
+    def examine(self, subject: SourceText) -> List[Issue]:
         '''
         Examines the text for white space at the end of lines.
 
@@ -67,7 +68,7 @@ class FortranRule(Rule, metaclass=ABCMeta):
     Parent for style rules pertaining to Fortran source.
     '''
     # pylint: disable=too-few-public-methods, abstract-method
-    def examine(self, subject):
+    def examine(self, subject: FortranSource) -> List[Issue]:
         issues = super(FortranRule, self).examine(subject)
 
         if not isinstance(subject, FortranSource):
@@ -84,7 +85,7 @@ class FortranRule(Rule, metaclass=ABCMeta):
         return issues
 
     @abstractmethod
-    def examine_fortran(self, subject):
+    def examine_fortran(self, subject: FortranSource):
         '''
         Examines the provided Fortran source code object for an issue.
 

--- a/source/stylist/style.py
+++ b/source/stylist/style.py
@@ -36,7 +36,7 @@ class Style(object):
         return [rule.__class__.__name__ for rule in self._rules]
 
     def check(self,
-              source: stylist.source.Source) -> List[stylist.issue.Issue]:
+              source: stylist.source.SourceTree) -> List[stylist.issue.Issue]:
         '''
         Applies every rule in this style to the parse tree.
 

--- a/source/stylist/style.py
+++ b/source/stylist/style.py
@@ -10,6 +10,7 @@ Classes relating to styles made up of rules.
 
 from abc import ABCMeta
 import logging
+from typing import List
 
 import stylist.fortran
 import stylist.issue
@@ -28,13 +29,14 @@ class Style(object):
             rules = [rules]
         self._rules = rules
 
-    def list_rules(self):
+    def list_rules(self) -> List[str]:
         '''
         Gets a list of the rules which make up this style.
         '''
         return [rule.__class__.__name__ for rule in self._rules]
 
-    def check(self, source):
+    def check(self,
+              source: stylist.source.Source) -> List[stylist.issue.Issue]:
         '''
         Applies every rule in this style to the parse tree.
 

--- a/source/stylist/style.py
+++ b/source/stylist/style.py
@@ -44,7 +44,7 @@ class Style(object):
                object.
         '''
         logging.getLogger(__name__).info('Style: ' + self.__class__.__name__)
-        issues = []
+        issues: List[stylist.issue.Issue] = []
         for rule in self._rules:
             issues.extend(rule.examine(source))
         return issues


### PR DESCRIPTION
This change adds type hinting to the program code. I have not added it to the unit tests as I'm not sure that wouldn't just confuse matters.

While developing the change I used `mypy <source directory>` to perform static type checking.
