### PR TITLE
Pipeline ID help text

### DIFF
--- a/source/stylist/__main__.py
+++ b/source/stylist/__main__.py
@@ -27,9 +27,12 @@ def parse_cli() -> argparse.Namespace:
     Parse the command line. Returns a dictionary of arguments.
     '''
     description = 'Perform various code style checks on source code.'
-    parsers = [key + ' ' * (8 - len(key)) + '- ' + str(parser)
+
+    max_key_length: int = max(len(key) for key in _LANGUAGE_MAP.keys())
+    parsers = [key.ljust(max_key_length) + ' - ' + str(parser)
                for key, parser in _LANGUAGE_MAP.items()]
-    preproc = [key + ' ' * (8 - len(key)) + '- ' + str(proc)
+    max_key_length = max(len(key) for key in _PREPROCESSOR_MAP.keys())
+    preproc = [key.ljust(max_key_length) + ' - ' + str(proc)
                for key, proc in _PREPROCESSOR_MAP.items()]
     epilog = '''\
 IDs used in specifying extension pipelines:

--- a/source/stylist/__main__.py
+++ b/source/stylist/__main__.py
@@ -27,14 +27,29 @@ def parse_cli() -> argparse.Namespace:
     Parse the command line. Returns a dictionary of arguments.
     '''
     description = 'Perform various code style checks on source code.'
+    parsers = [key + ' ' * (8 - len(key)) + '- ' + str(parser)
+               for key, parser in _LANGUAGE_MAP.items()]
+    preproc = [key + ' ' * (8 - len(key)) + '- ' + str(proc)
+               for key, proc in _PREPROCESSOR_MAP.items()]
+    epilog = '''\
+IDs used in specifying extension pipelines:
+  Parsers:
+    {parsers}
+  Preprocessors:
+    {preproc}
+    '''.format(parsers='\n    '.join(parsers),
+               preproc='\n    '.join(preproc))
+    formatter_class = argparse.RawDescriptionHelpFormatter
     cli_parser = argparse.ArgumentParser(add_help=False,
-                                         description=description)
+                                         description=description,
+                                         epilog=epilog,
+                                         formatter_class=formatter_class)
     cli_parser.add_argument('-help', '-h', '--help', action='help')
     cli_parser.add_argument('-verbose', '-v', action="store_true",
                             help='Produce a running commentary on progress')
-    message = 'Add a mapping between file extension and language'
+    message = 'Add a mapping between file extension and pipeline'
     cli_parser.add_argument('-map-extension',
-                            metavar='EXTENSION:LANGUAGE[:PREPROCESSOR]',
+                            metavar='EXTENSION:PARSER[:PREPROCESSOR]',
                             dest='map_extension',
                             default=[],
                             action='append',

--- a/source/stylist/source.py
+++ b/source/stylist/source.py
@@ -79,7 +79,12 @@ class TextProcessor(SourceText, metaclass=ABCMeta):
         self._source = source
 
 
-class CPreProcessor(TextProcessor):
+class MetaCPreProcessor(TextProcessor.__class__):
+    def __str__(self):
+        return "C preprocessor"
+
+
+class CPreProcessor(TextProcessor, metaclass=MetaCPreProcessor):
     # pylint: disable=too-few-public-methods
     '''
     Strips out preprocessor directives.
@@ -104,7 +109,12 @@ class CPreProcessor(TextProcessor):
         return text
 
 
-class FortranPreProcessor(TextProcessor):
+class MetaFortranPreProcessor(TextProcessor.__class__):
+    def __str__(self):
+        return "Fortran preprocessor"
+
+
+class FortranPreProcessor(TextProcessor, metaclass=MetaFortranPreProcessor):
     # pylint: disable=too-few-public-methods
     '''
     Strips out preprocessor directives.
@@ -129,7 +139,12 @@ class FortranPreProcessor(TextProcessor):
         return text
 
 
-class PFUnitProcessor(TextProcessor):
+class MetaPFUnitProcessor(TextProcessor.__class__):
+    def __str__(self):
+        return "pFUnit preprocessor"
+
+
+class PFUnitProcessor(TextProcessor, metaclass=MetaPFUnitProcessor):
     # pylint: disable=too-few-public-methods
     '''
     Strips out pFUnit directives.
@@ -178,7 +193,12 @@ class SourceTree(object, metaclass=ABCMeta):
         return self._text.get_text()
 
 
-class FortranSource(SourceTree):
+class MetaFortranSource(SourceTree.__class__):
+    def __str__(self):
+        return 'Fortran source'
+
+
+class FortranSource(SourceTree, metaclass=MetaFortranSource):
     '''
     Holds a Fortran source file as both a text block and parse tree.
     '''
@@ -348,7 +368,12 @@ class FortranSource(SourceTree):
                 FortranSource.print_tree(child.items, indent+1)
 
 
-class CSource(SourceTree):
+class MetaCSource(SourceTree.__class__):
+    def __str__(self):
+        return "C source"
+
+
+class CSource(SourceTree, metaclass=MetaCSource):
     '''
     Holds a C/C++ source file as both a text block and parse tree.
     '''

--- a/tests/source_test.py
+++ b/tests/source_test.py
@@ -278,6 +278,7 @@ class TestCSource(object):
     '''
     def test_name(self):
         assert str(CSource) == 'C source'
+
     def test_constructor(self):
         '''
         Checks that the source file is correctly parsed on construction.

--- a/tests/source_test.py
+++ b/tests/source_test.py
@@ -61,6 +61,9 @@ class TestSourceText(object):
 
 
 class TestPPFortranSource(object):
+    def test_name(self):
+        assert str(FortranPreProcessor) == 'Fortran preprocessor'
+
     def test_preprocessed_fortran_source(self):
         # pylint: disable=no-self-use
         source = '''! Some things happen, others don't
@@ -99,6 +102,9 @@ end module test_mod
 
 
 class TestPPpFUnitSource(object):
+    def test_name(self):
+        assert str(PFUnitProcessor) == 'pFUnit preprocessor'
+
     def test_preprocessed_pfunit_source(self):
         # pylint: disable=no-self-use
         source = '''! Test all the things
@@ -127,6 +133,9 @@ end module test_mod
 
 
 class TestPPCSource(object):
+    def test_name(self):
+        assert str(CPreProcessor) == 'C preprocessor'
+
     def test_preprocessed_c_source(self):
         # pylint: disable=no-self-use
         source = '''/* Some things happen, others don't */
@@ -162,6 +171,9 @@ class TestFortranSource(object):
     '''
     Checks the Fortran source class.
     '''
+    def test_name(self):
+        assert str(FortranSource) == 'Fortran source'
+
     def test_constructor(self):
         '''
         Checks that the source file is correctly parsed on construction.
@@ -264,6 +276,8 @@ class TestCSource(object):
     '''
     Checks the C/C++ source class.
     '''
+    def test_name(self):
+        assert str(CSource) == 'C source'
     def test_constructor(self):
         '''
         Checks that the source file is correctly parsed on construction.


### PR DESCRIPTION
As per issue #10 - Provides help on IDs to use when specifying pipelines.

The original plan was to provide a separate argument which would spit out the list but `argparse` does not easily support that mode of operation. Instead they are always printed out with the help text. This is probably a better solution while the number is small but might become unwieldy later.
