### PR TITLE
Pointer initialisation rule

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     package_dir={'': 'source'},
     packages=find_packages(where='source'),
     python_requires='>=3.6, <4',
-    install_requires=['fparser'],
+    install_requires=['fparser > 0.0.10'],
     extras_require={
         'dev': ['check-manifest', 'flake8'],
         'test': ['pytest', 'pytest-cov'],

--- a/source/stylist/fortran.py
+++ b/source/stylist/fortran.py
@@ -4,21 +4,21 @@
 # The file LICENCE, distributed with this code, contains details of the terms
 # under which the code may be used.
 ##############################################################################
-'''
+"""
 Rules relating to Fortran source.
-'''
+"""
 from typing import List
 
-import fparser.two.Fortran2003
+import fparser.two.Fortran2003 as Fortran2003
 from stylist.issue import Issue
 from stylist.rule import Rule, FortranRule
 
 
 class FortranCharacterset(Rule):
     # pylint: disable=too-few-public-methods
-    '''
+    """
     Scans the source for characters which are not supported by Fortran.
-    '''
+    """
     _FORTRAN_LETTER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
     _FORTRAN_DIGIT = '0123456789'
     _FORTRAN_ALPHANUMERIC = _FORTRAN_LETTER + _FORTRAN_DIGIT + '_'
@@ -32,13 +32,13 @@ class FortranCharacterset(Rule):
 
     def examine(self, subject):
         # pylint: disable=too-many-branches
-        '''
+        """
         Examines the source code for none Fortran characters.
 
         This is complicated by the fact that the source must consist of only
         certain characters except comments and strings. These may contain
         anything.
-        '''
+        """
         issues = super(FortranCharacterset, self).examine(subject)
 
         text = subject.get_text()
@@ -82,12 +82,13 @@ class FortranCharacterset(Rule):
 
 class MissingImplicit(FortranRule):
     # pylint: disable=too-few-public-methods
-    '''
+    """
     Catches cases where code blocks which could have an "implicit" statement
     don't.
-    '''
+    """
+
     def __init__(self, default='none'):
-        '''
+        """
         Constructor taking a default implication.
 
         Todo: This rule was designed to check merely for the presence of an
@@ -100,14 +101,14 @@ class MissingImplicit(FortranRule):
         Todo: At the moment the default is not used. In the future we may want
         to allow rules to enforce style rather than simply reporting it. In
         this case the default would be used where none is present.
-        '''
+        """
         assert default.lower() in ('none', 'private', 'public')
         self._default = default.lower()
 
-    _NATURE_MAP = {fparser.two.Fortran2003.Program_Stmt: 'Program',
-                   fparser.two.Fortran2003.Module_Stmt: 'Module',
-                   fparser.two.Fortran2003.Subroutine_Stmt: 'Subroutine',
-                   fparser.two.Fortran2003.Function_Stmt: 'Function'}
+    _NATURE_MAP = {Fortran2003.Program_Stmt: 'Program',
+                   Fortran2003.Module_Stmt: 'Module',
+                   Fortran2003.Subroutine_Stmt: 'Subroutine',
+                   Fortran2003.Function_Stmt: 'Function'}
 
     def examine_fortran(self, subject):
         issues = []
@@ -137,21 +138,22 @@ class MissingImplicit(FortranRule):
 
 
 class MissingOnly(FortranRule):
-    '''
+    """
     Catches cases where a "use" statement is present but has no "only" claus.
-    '''
+    """
+
     def __init__(self, ignore=[]):
-        '''
+        """
         Constructs a "MissingOnly" rule object taking a list of exception
         modules which are not required to have an "only" clause.
-        '''
+        """
         assert isinstance(ignore, list)
         self._ignore = ignore
 
     def examine_fortran(self, subject):
         issues = []
 
-        for statement in subject.find_all(fparser.two.Fortran2003.Use_Stmt):
+        for statement in subject.find_all(Fortran2003.Use_Stmt):
             module = statement.items[2]
             onlies = statement.items[4]
             if str(module).lower() not in self._ignore:
@@ -166,9 +168,11 @@ class MissingPointerInit(FortranRule):
     """
     Catches cases where a pointer is declared without being initialised.
     """
+
     def __init__(self, default='null()'):
         """
-        Constructs a MissingPointerInit rule object taking a default assignment.
+        Constructs a MissingPointerInit rule object taking a default
+        assignment.
 
         Todo: Obviously the default is not used as we don't support coercing
               source at the moment.
@@ -180,29 +184,37 @@ class MissingPointerInit(FortranRule):
     def examine_fortran(self, subject):
         issues: List[Issue] = []
 
-        candidates: List[fparser.two.Fortran2003.StmtBase] = []
+        candidates: List[Fortran2003.StmtBase] = []
         # Component variables
-        candidates.extend(subject.find_all(fparser.two.Fortran2003.Data_Component_Def_Stmt))
+        candidates.extend(
+            subject.find_all(Fortran2003.Data_Component_Def_Stmt))
         # Component Procedure
-        candidates.extend(subject.find_all(fparser.two.Fortran2003.Proc_Component_Def_Stmt))
+        candidates.extend(
+            subject.find_all(Fortran2003.Proc_Component_Def_Stmt))
         # Procedure declaration
-        candidates.extend(subject.find_all(fparser.two.Fortran2003.Procedure_Declaration_Stmt))
+        candidates.extend(
+            subject.find_all(Fortran2003.Procedure_Declaration_Stmt))
         # Variable declaration
-        candidates.extend(subject.find_all(fparser.two.Fortran2003.Type_Declaration_Stmt))
+        candidates.extend(
+            subject.find_all(Fortran2003.Type_Declaration_Stmt))
 
         return_variable = ''
         for statement in candidates:
             if isinstance(statement,  # Is variable
-                          (fparser.two.Fortran2003.Data_Component_Def_Stmt,
-                           fparser.two.Fortran2003.Type_Declaration_Stmt)):
-                if isinstance(statement.parent.parent, fparser.two.Fortran2003.Function_Subprogram):
+                          (Fortran2003.Data_Component_Def_Stmt,
+                           Fortran2003.Type_Declaration_Stmt)):
+                if isinstance(statement.parent.parent,
+                              Fortran2003.Function_Subprogram):
                     # Is contained in a function
-                    function_block: fparser.two.Fortran2003.Function_Subprogram = statement.parent.parent
+                    function_block: Fortran2003.Function_Subprogram \
+                        = statement.parent.parent
                     suffix = function_block.children[0].items[3]
-                    if isinstance(suffix, fparser.two.Fortran2003.Suffix):
-                        if isinstance(suffix.items[0], fparser.two.Fortran2003.Name):
+                    if isinstance(suffix, Fortran2003.Suffix):
+                        if isinstance(suffix.items[0], Fortran2003.Name):
                             # Is return variable
                             return_variable = str(suffix.items[0])
+
+            problem = 'Declaration of pointer "{0}" without initialisation.'
 
             attributes = statement.items[1]
             if attributes is None:
@@ -215,24 +227,24 @@ class MissingPointerInit(FortranRule):
             if 'pointer' in cannon_attr and not argument_def:
                 for variable in statement.items[2].items:
                     if isinstance(statement,  # Is variable
-                                  (fparser.two.Fortran2003.Data_Component_Def_Stmt,
-                                   fparser.two.Fortran2003.Type_Declaration_Stmt)):
+                                  (Fortran2003.Data_Component_Def_Stmt,
+                                   Fortran2003.Type_Declaration_Stmt)):
                         name = str(variable.items[0])
                         if name == return_variable:
                             continue  # Return variables cannot be initialised.
                         init = variable.items[3]
                         if init is None:
-                            description = 'Declaration of pointer "' + name + '" without initialisation.'
-                            issues.append(Issue(description))
+                            issues.append(Issue(problem.format(name)))
                     elif isinstance(statement,  # Is procedure
-                                    (fparser.two.Fortran2003.Proc_Component_Def_Stmt,
-                                     fparser.two.Fortran2003.Procedure_Declaration_Stmt)):
+                                    (Fortran2003.Proc_Component_Def_Stmt,
+                                     Fortran2003.Procedure_Declaration_Stmt)):
                         name = str(variable)
-                        if isinstance(variable, fparser.two.Fortran2003.Name):
-                            description = 'Declaration of pointer "' + name + '" without initialisation.'
-                            issues.append(Issue(description))
+                        if isinstance(variable, Fortran2003.Name):
+                            issues.append(Issue(problem.format(name)))
                     else:
-                        raise Exception(f"Unexpected source element: {repr(statement)}")
+                        message \
+                            = f"Unexpected source element: {repr(statement)}"
+                        raise Exception(message)
 
         issues.sort()
         return issues

--- a/tests/fortran_pointer_init_test.py
+++ b/tests/fortran_pointer_init_test.py
@@ -4,52 +4,53 @@
 # The file LICENCE, distributed with this code, contains details of the terms
 # under which the code may be used.
 ##############################################################################
-'''
+"""
 Test of the rule for missing pointer initialisation.
-'''
+"""
 from typing import List
 
 import pytest
 import stylist.fortran
 from stylist.source import FortranSource, SourceStringReader
 
+
 class TestMissingPointerInit(object):
-    '''
+    """
     Tests the checker of missing pointer initialisation.
-    '''
+    """
     @pytest.fixture(scope='class',
                     params=['program', 'module'])
     def prog_unit(self, request):
-        '''
+        """
         Parameter fixture giving program unit types.
-        '''
+        """
         # pylint: disable=no-self-use
         yield request.param
 
     @pytest.fixture(scope='class',
                     params=['', 'pointer', 'nullpointer'])
     def type_pointer(self, request):
-        '''
+        """
         Parameter fixture giving pointer type for program unit.
-        '''
+        """
         # pylint: disable=no-self-use
         yield request.param
 
     @pytest.fixture(scope='class',
                     params=['', 'pointer', 'nullpointer'])
     def unit_pointer(self, request):
-        '''
+        """
         Parameter fixture giving pointer type for program unit.
-        '''
+        """
         # pylint: disable=no-self-use
         yield request.param
 
     @pytest.fixture(scope='class',
                     params=['', 'pointer', 'nullpointer'])
     def proc_pointer(self, request):
-        '''
+        """
         Parameter fixture giving pointer type for procedure.
-        '''
+        """
         # pylint: disable=no-self-use
         yield request.param
 
@@ -65,73 +66,68 @@ class TestMissingPointerInit(object):
                           type_pointer,
                           unit_pointer,
                           proc_pointer):
-        '''
+        """
         Checks that the rule reports missing pointer initialisation correctly.
-        '''
+        """
         template = '''
-               {prog_unit} test
-                 implicit none
-                 private
-                 type foo_type
-                   private
-                   integer{type_attr} :: type_{type_decl}, second_type_{type_decl}
-                   ! Procedure pointers have to be pointers.
-                   procedure(some_if), nopass, pointer :: type_proc_pointer_{type_decl}, &
-                                                          other_type_proc_pointer_{type_decl}
-                 end type foo_type
-                 type(foo_type){unit_attr} :: unit_{unit_decl}
-                 procedure(some_if){unit_attr} :: unit_proc_{unit_decl}
-               contains
-                 subroutine bar()
-                   implicit none
-                   type(foo_type){proc_attr} :: proc_{proc_decl}
-                   procedure(some_if){proc_attr} :: proc_proc_{proc_decl}
-                 end subroutine bar
-                 function qux() result(answer)
-                   implicit none
-                   ! It isn't possible to initialise function return variables
-                   real, pointer :: answer(:)
-                 end function qux
-                 logical function whatev()
-                   ! Functions may also be declared this way.
-                   implicit none
-                   whatev = .true.
-                 end function whatev
-                 subroutine baz( thing, thang, thong, bong )
-                   implicit none
-                   ! Intent in arguments aren't initialised
-                   type(foo_type), intent(in), pointer :: thing
-                   procedure(some_if), intent(in), pointer :: thang
-                   ! Oddly intent out arguments can't be initialised either
-                   logical, intent(out), pointer :: bong
-                   !Intent inout arguments aren't initialised
-                   real, intent(in out), pointer :: thong(:)
-                 end subroutine baz
-               end {prog_unit} test
-               '''
+{prog_unit} test
+  implicit none
+  private
+  type foo_type
+    private
+    integer{type_attr} :: type_{type_decl}, second_type_{type_decl}
+    ! Procedure pointers have to be pointers.
+    procedure(some_if), nopass, pointer :: type_proc_pointer_{type_decl}, &
+                                           other_type_proc_pointer_{type_decl}
+  end type foo_type
+  type(foo_type){unit_attr} :: unit_{unit_decl}
+  procedure(some_if){unit_attr} :: unit_proc_{unit_decl}
+contains
+  subroutine bar()
+    implicit none
+    type(foo_type){proc_attr} :: proc_{proc_decl}
+    procedure(some_if){proc_attr} :: proc_proc_{proc_decl}
+  end subroutine bar
+  function qux() result(answer)
+    implicit none
+    ! It isn't possible to initialise function return variables
+    real, pointer :: answer(:)
+  end function qux
+  logical function whatev()
+    ! Functions may also be declared this way.
+    implicit none
+    whatev = .true.
+  end function whatev
+  subroutine baz( thing, thang, thong, bong )
+    implicit none
+    ! Intent in arguments aren't initialised
+    type(foo_type), intent(in), pointer :: thing
+    procedure(some_if), intent(in), pointer :: thang
+    ! Oddly intent out arguments can't be initialised either
+    logical, intent(out), pointer :: bong
+    !Intent inout arguments aren't initialised
+    real, intent(in out), pointer :: thong(:)
+  end subroutine baz
+end {prog_unit} test
+'''
 
         expectation: List[str] = []
+        message = 'Declaration of pointer "{0}" without initialisation.'
         if type_pointer != 'nullpointer':
-            proc_pointer_suffix = self._DECL_MAP[type_pointer].partition(' ')[0]
+            suffix = self._DECL_MAP[type_pointer].partition(' ')[0]
             expectation.extend([
-                f'Declaration of pointer "other_type_proc_pointer_{proc_pointer_suffix}" without initialisation.',
-                f'Declaration of pointer "type_proc_pointer_{proc_pointer_suffix}" without initialisation.'
-                ])
+                message.format(f'other_type_proc_pointer_{suffix}'),
+                message.format(f'type_proc_pointer_{suffix}')
+            ])
         if type_pointer == 'pointer':
-            expectation.append(
-                'Declaration of pointer "second_type_bare" without initialisation.')
-            expectation.append(
-                'Declaration of pointer "type_bare" without initialisation.')
+            expectation.extend([message.format('second_type_bare'),
+                                message.format('type_bare')])
         if proc_pointer == 'pointer':
-            expectation.append(
-                'Declaration of pointer "proc_bare" without initialisation.')
-            expectation.append(
-                'Declaration of pointer "proc_proc_bare" without initialisation.')
+            expectation.extend([message.format('proc_bare'),
+                                message.format('proc_proc_bare')])
         if unit_pointer == 'pointer':
-            expectation.append(
-                'Declaration of pointer "unit_bare" without initialisation.')
-            expectation.append(
-                'Declaration of pointer "unit_proc_bare" without initialisation.')
+            expectation.extend([message.format('unit_bare'),
+                                message.format('unit_proc_bare')])
         expectation.sort()
 
         text = template.format(


### PR DESCRIPTION
In the LFRic project we like pointers to be initialised when they are declared.

Closes #16.