### PR TITLE
Extract map between extension and processing stages to configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+minversion = 6.0.0
+testpaths = unit-tests system-tests
+addopts = --failed-first
+xfail_strict = True

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     package_dir={'': 'source'},
     packages=find_packages(where='source'),
     python_requires='>=3.6, <4',
-    install_requires=['fparser > 0.0.12'],
+    install_requires=['fparser >= 0.0.12'],
     extras_require={
         'dev': ['check-manifest', 'flake8', 'mypy'],
         'test': ['pytest', 'pytest-cov'],

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     package_dir={'': 'source'},
     packages=find_packages(where='source'),
     python_requires='>=3.6, <4',
-    install_requires=['fparser > 0.0.10'],
+    install_requires=['fparser > 0.0.12'],
     extras_require={
         'dev': ['check-manifest', 'flake8', 'mypy'],
         'test': ['pytest', 'pytest-cov'],

--- a/source/stylist/__main__.py
+++ b/source/stylist/__main__.py
@@ -27,11 +27,15 @@ def _parse_cli() -> argparse.Namespace:
     """
     description = 'Perform various code style checks on source code.'
 
-    max_key_length: int = max(len(key) for key in Configuration.language_tags())
-    parsers = [key.ljust(max_key_length) + ' - ' + str(Configuration.language_lookup(key))
+    max_key_len: int = max(len(key) for key in Configuration.language_tags())
+    parsers = [key.ljust(max_key_len)
+               + ' - '
+               + str(Configuration.language_lookup(key))
                for key in Configuration.language_tags()]
-    max_key_length = max(len(key) for key in Configuration.preprocessor_tags())
-    preproc = [key.ljust(max_key_length) + ' - ' + str(Configuration.preprocessor_lookup(key))
+    max_key_len = max(len(key) for key in Configuration.preprocessor_tags())
+    preproc = [key.ljust(max_key_len)
+               + ' - '
+               + str(Configuration.preprocessor_lookup(key))
                for key in Configuration.preprocessor_tags()]
     epilog = """"\
 IDs used in specifying extension pipelines:
@@ -139,7 +143,8 @@ def main() -> None:
     # Pipelines from command line.
     #
     for mapping in arguments.map_extension:
-        extension, language, preprocessors = Configuration.parse_pipe_description(mapping)
+        extension, language, preprocessors \
+            = Configuration.parse_pipe_description(mapping)
         SourceFactory.add_extension(extension, language, *preprocessors)
 
     issues = _process(arguments.source, styles)

--- a/source/stylist/configuration.py
+++ b/source/stylist/configuration.py
@@ -31,7 +31,7 @@ class Configuration(ABC):
     #
     def __init__(self,
                  parameters: Mapping[str,
-                                     Mapping[str, str]],
+                                     Mapping[str, str]] = {},
                  defaults: 'Configuration' = None):
         self._defaults = defaults
         self._parameters = parameters
@@ -47,7 +47,7 @@ class Configuration(ABC):
         return cls._LANGUAGE_MAP.keys()
 
     @classmethod
-    def language_lookup(cls, key: str) -> SourceTree:
+    def language_lookup(cls, key: str) -> Type[SourceTree]:
         return cls._LANGUAGE_MAP[key]
 
     _PREPROCESSOR_MAP: Mapping[str, Type[TextProcessor]] \
@@ -60,7 +60,7 @@ class Configuration(ABC):
         return cls._PREPROCESSOR_MAP.keys()
 
     @classmethod
-    def preprocessor_lookup(cls, key: str) -> TextProcessor:
+    def preprocessor_lookup(cls, key: str) -> Type[TextProcessor]:
         return cls._PREPROCESSOR_MAP[key]
 
     @classmethod
@@ -88,7 +88,6 @@ class Configuration(ABC):
             for extension in section:
                 result.append(self.parse_pipe_description(f'{extension}:{section[extension]}'))
         return result
-
 
     _STYLE_PREFIX = 'style.'
 

--- a/source/stylist/configuration.py
+++ b/source/stylist/configuration.py
@@ -31,10 +31,13 @@ class Configuration(ABC):
     #
     def __init__(self,
                  parameters: Mapping[str,
-                                     Mapping[str, str]] = {},
+                                     Mapping[str, str]] = None,
                  defaults: 'Configuration' = None):
         self._defaults = defaults
-        self._parameters = parameters
+        if parameters is not None:
+            self._parameters = parameters
+        else:
+            self._parameters = {}
 
     _LANGUAGE_MAP: Mapping[str, Type[SourceTree]] \
         = {'c': CSource,

--- a/source/stylist/configuration.py
+++ b/source/stylist/configuration.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+##############################################################################
+# (c) Crown copyright 2020 Met Office. All rights reserved.
+# The file LICENCE, distributed with this code, contains details of the terms
+# under which the code may be used.
+##############################################################################
+"""
+Handles configuration parameters coming from various potential sources.
+
+Configuration may be defined by software or read from a Windows .ini file.
+"""
+from abc import ABC
+from configparser import ConfigParser, MissingSectionHeaderError
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Set, Sequence, Union
+
+
+class Configuration(ABC):
+    # Pycharm is confused by referring to the class you are defining. mypy is
+    # fine with it.
+    #
+    def __init__(self,
+                 parameters: Mapping[str, Mapping[str, Union[str,
+                                                             int,
+                                                             List[str]]]],
+                 defaults: 'Configuration' = None):
+        self._defaults = defaults
+        self._parameters = parameters
+
+    def section_names(self, prefix=None) -> Sequence[str]:
+        """
+        Gets a tuple of all section names.
+        """
+        candidates: Set[str] = set(self._parameters.keys())
+        if self._defaults is not None:
+            candidates = candidates.union(self._defaults.section_names())
+        names: Iterable[str]
+        if prefix is not None:
+            names = [name for name in candidates
+                     if name.startswith(prefix)]
+        else:  # prefix is None
+            names = candidates
+        return list(sorted(names))
+
+    def section(self, name: str) -> Mapping[str, Union[str, int, List[str]]]:
+        """
+        Gets a mapping of all key/value pairs from a section.
+        """
+        parameters: Dict[str, Union[str, int, List[str]]]
+        if self._defaults is not None:
+            parameters = dict(self._defaults.section(name))
+        else:
+            parameters = {}
+        try:
+            parameters.update(self._parameters[name])
+        except KeyError:
+            pass  # Not an error
+        return parameters
+
+
+class ConfigurationFile(Configuration):
+    """
+    Configuration parameters read from a Windows .ini format file.
+    """
+    _LISTS = ['rules']
+
+    def __init__(self,
+                 filename: Path,
+                 defaults: Configuration = None) -> None:
+        """
+        Builds a configuration object from a filename.
+        """
+        parser = ConfigParser()
+        try:
+            with filename.open('rt') as handle:
+                parser.read_file(handle)
+        except MissingSectionHeaderError:
+            pass  # It is not an error to have an empty configuration file.
+        parameters: Dict[str, Dict[str, Union[str, List[str]]]] = {}
+        for section in parser.sections():
+            parameters[section] = {}
+            for key, value in parser.items(section):
+                if key in self._LISTS:
+                    parameters[section][key] = value.split(',')
+                else:
+                    parameters[section][key] = value
+        super().__init__(parameters, defaults)

--- a/source/stylist/configuration.py
+++ b/source/stylist/configuration.py
@@ -64,7 +64,10 @@ class Configuration(ABC):
         return cls._PREPROCESSOR_MAP[key]
 
     @classmethod
-    def parse_pipe_description(cls, string: str) -> Tuple[str, Type[SourceTree], Sequence[Type[TextProcessor]]]:
+    def parse_pipe_description(cls, string: str) \
+        -> Tuple[str,
+                 Type[SourceTree],
+                 Sequence[Type[TextProcessor]]]:
         if not string:
             raise StylistException("Empty extension pipe description")
 
@@ -78,7 +81,9 @@ class Configuration(ABC):
             preproc_objects = []
         return extension, lang_object, preproc_objects
 
-    def get_file_pipes(self) -> Sequence[Tuple[str, Type[SourceTree], Sequence[Type[TextProcessor]]]]:
+    def get_file_pipes(self) -> Sequence[Tuple[str,
+                                               Type[SourceTree],
+                                               Sequence[Type[TextProcessor]]]]:
         """
         Enumerates the extension handling pipelines.
         """
@@ -86,7 +91,8 @@ class Configuration(ABC):
         section = self._parameters.get('file-pipe')
         if section is not None:
             for extension in section:
-                result.append(self.parse_pipe_description(f'{extension}:{section[extension]}'))
+                descr = f'{extension}:{section[extension]}'
+                result.append(self.parse_pipe_description(descr))
         return result
 
     _STYLE_PREFIX = 'style.'

--- a/source/stylist/style.py
+++ b/source/stylist/style.py
@@ -64,12 +64,9 @@ def _all_subclasses(cls: Any) -> Set[Type]:
     return children
 
 
-_PREFIX = 'style.'
-
-
 def determine_style(configuration: Configuration,
                     style_name: Optional[str] = None) -> Style:
-    available_styles = configuration.section_names(_PREFIX)
+    available_styles = configuration.available_styles()
 
     if style_name is None:
         if len(available_styles) == 1:
@@ -78,8 +75,6 @@ def determine_style(configuration: Configuration,
             message = "Cannot pick a default style from file containing " \
                       "{0} styles"
             raise StylistException(message.format(len(available_styles)))
-    else:
-        style_name = f'style.{style_name}'
 
     if style_name not in available_styles:
         message = f"style '{style_name}' not found in configuration"
@@ -92,7 +87,7 @@ def determine_style(configuration: Configuration,
         = {cls.__name__: cls for cls in _all_subclasses(stylist.rule.Rule)}
 
     rules: List[stylist.rule.Rule] = []
-    rule_list = configuration.section(style_name)['rules']
+    rule_list = configuration.get_style(style_name)
     if not isinstance(rule_list, list):
         raise TypeError('Style rules should be a list of names')
     for rule_description in rule_list:

--- a/source/stylist/style.py
+++ b/source/stylist/style.py
@@ -8,12 +8,11 @@
 Classes relating to styles made up of rules.
 """
 from abc import ABCMeta
-import configparser
 import logging
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Type
 
 from stylist import StylistException
+from stylist.configuration import Configuration
 import stylist.fortran
 import stylist.issue
 import stylist.rule
@@ -65,19 +64,12 @@ def _all_subclasses(cls: Any) -> Set[Type]:
     return children
 
 
-def read_style(rule_file: Path, style_name: Optional[str] = None) -> Style:
-    PREFIX = 'style.'
+_PREFIX = 'style.'
 
-    configuration = configparser.ConfigParser()
-    try:
-        with rule_file.open('rt') as handle:
-            configuration.read_file(handle)
-    except configparser.MissingSectionHeaderError:
-        pass  # It is not an error to have an empty configuration file.
 
-    available_styles = [section[len(PREFIX):]
-                        for section in configuration.sections()
-                        if section.startswith(PREFIX)]
+def determine_style(configuration: Configuration,
+                    style_name: Optional[str] = None) -> Style:
+    available_styles = configuration.section_names(_PREFIX)
 
     if style_name is None:
         if len(available_styles) == 1:
@@ -86,9 +78,11 @@ def read_style(rule_file: Path, style_name: Optional[str] = None) -> Style:
             message = "Cannot pick a default style from file containing " \
                       "{0} styles"
             raise StylistException(message.format(len(available_styles)))
+    else:
+        style_name = f'style.{style_name}'
 
     if style_name not in available_styles:
-        message = f"style {style_name} not found in configuration"
+        message = f"style '{style_name}' not found in configuration"
         raise StylistException(message)
 
     # Todo: It would be nice to remove abstracts from this list but I haven't
@@ -98,8 +92,10 @@ def read_style(rule_file: Path, style_name: Optional[str] = None) -> Style:
         = {cls.__name__: cls for cls in _all_subclasses(stylist.rule.Rule)}
 
     rules: List[stylist.rule.Rule] = []
-    rule_string = configuration['style.' + style_name]['rules']
-    for rule_description in rule_string.split(','):
+    rule_list = configuration.section(style_name)['rules']
+    if not isinstance(rule_list, list):
+        raise TypeError('Style rules should be a list of names')
+    for rule_description in rule_list:
         rule_name, _, rule_arguments_string = rule_description.partition('(')
         rule_name = rule_name.strip()
         rule_arguments_string, _, _ = rule_arguments_string.partition(')')

--- a/system-tests/simple/configuration.ini
+++ b/system-tests/simple/configuration.ini
@@ -1,2 +1,5 @@
+[file-pipe]
+txt = text
+
 [style.simple]
 rules = TrailingWhitespace

--- a/system-tests/style_configuration_test.py
+++ b/system-tests/style_configuration_test.py
@@ -9,7 +9,7 @@ System tests using a style from configuration.
 """
 from pathlib import Path
 import subprocess
-from typing import List, Tuple
+from typing import List
 
 from pytest import fixture  # type: ignore
 # ToDo: Obviously we shouldn't be importing "private" modules but until pytest
@@ -18,27 +18,32 @@ from pytest import fixture  # type: ignore
 from _pytest.fixtures import FixtureRequest  # type: ignore
 
 
+class _CaseParam:
+    def __init__(self, style: str, name: str, files: List[str], rc: int) \
+            -> None:
+        self.style = style
+        self.name = name
+        self.files = files
+        self.rc = rc
+
+
 class TestSystem(object):
     @fixture(scope='class',
-             params=[('simple', 'Single file, no problem', ['nice.txt'], 0),
-                     ('simple', 'Dual file, no problem', ['nice.txt',
-                                                          'fluffy.txt'], 0),
-                     ('simple', 'Single file, problem', ['naughty.txt'], 1),
-                     ('simple', 'Dual file, mixed', ['nice.txt',
-                                                     'naughty.txt'], 1)])
-    def case(self, request: FixtureRequest) \
-            -> Tuple[str, str, List[str], int]:
+             params=[_CaseParam('simple', 'Single file, no problem',
+                                ['nice.txt'], 0),
+                     _CaseParam('simple', 'Dual file, no problem',
+                                ['nice.txt', 'fluffy.txt'], 0),
+                     _CaseParam('simple', 'Single file, problem',
+                                ['naughty.txt'], 1),
+                     _CaseParam('simple', 'Dual file, mixed',
+                                ['nice.txt', 'naughty.txt'], 1)])
+    def case(self, request: FixtureRequest) -> _CaseParam:
         return request.param
 
-    def test_case(self, case: Tuple[str, str, List[str], int]):
-        test_style: str = case[0]
-        test_name: str = case[1]
-        test_files: List[str] = case[2]
-        expected_rc: int = case[3]
+    def test_case(self, case: _CaseParam):
+        test_dir = Path(__file__).parent / case.style
 
-        test_dir = Path(__file__).parent / test_style
-
-        expected_tag = ''.join([word[0].lower() for word in test_name.split()])
+        expected_tag = ''.join([word[0].lower() for word in case.name.split()])
         expected_output: List[str] = []
         expected_error: List[str] = []
         buffer: List[str] = expected_output
@@ -54,12 +59,12 @@ class TestSystem(object):
         command: List[str] = ['python', '-m', 'stylist',
                               '-configuration',
                               str(test_dir / 'configuration.ini'),
-                              '-style', test_style]
-        command.extend([str(test_dir / leafname) for leafname in test_files])
+                              '-style', case.style]
+        command.extend([str(test_dir / leafname) for leafname in case.files])
         process = subprocess.run(command,
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
-        assert process.returncode == expected_rc
+        assert process.returncode == case.rc
         assert process.stderr.decode('utf-8').strip() \
             == ''.join(expected_error).strip()
         assert process.stdout.decode('utf-8').strip() \

--- a/unit-tests/configuration_test.py
+++ b/unit-tests/configuration_test.py
@@ -5,7 +5,7 @@
 # under which the code may be used.
 ##############################################################################
 """Ensure the configuration module functions as expected."""
-from typing import Mapping
+from typing import Mapping, Optional, Sequence, Tuple, Type
 from pytest import fixture, raises  # type: ignore
 # ToDo: Obviously we shouldn't be importing "private" modules but until pytest
 #       sorts out its type hinting we are stuck with it.
@@ -14,25 +14,40 @@ from _pytest.fixtures import FixtureRequest  # type: ignore
 
 from stylist import StylistException
 from stylist.configuration import ConfigurationFile, Configuration
+from stylist.source import (CPreProcessor,
+                            CSource,
+                            FortranPreProcessor,
+                            FortranSource,
+                            PFUnitProcessor,
+                            SourceTree,
+                            TextProcessor)
 
+
+@fixture(scope='module',
+         params=((None, None),
+                 ('boo:fortran', ('boo', FortranSource, [])),
+                 ('coo:c:cpp',('coo', CSource, [CPreProcessor])),
+                 ('doo:fortran:pfp:fpp', ('doo', FortranSource, [PFUnitProcessor, FortranPreProcessor]))))
+def pipe_string(request: FixtureRequest) -> Tuple[str, Optional[Tuple[str, Type[SourceTree], Sequence[Type[TextProcessor]]]]]:
+    return request.param
 
 @fixture(scope='module',
          params=({'style.only-rules': {'rules': 'foo-rule'}},
                  {'style.only-multi-rules': {'rules': 'teapot-rule, cheese-rule'}},
                  {'style.plus-rules': {'rules': 'bar-rule',
                                        'second': 'other thing'}}))
-def case(request: FixtureRequest) -> Mapping[str, Mapping[str, str]]:
+def style_file(request: FixtureRequest) -> Mapping[str, Mapping[str, str]]:
     return request.param
 
 
 class TestConfiguration():
-    def test_configuration(self, case) -> None:
-        test_unit = Configuration(case)
-        expected = [key[6:] for key in case.keys() if key.startswith('style.')]
+    def test_configuration(self, style_file) -> None:
+        test_unit = Configuration(style_file)
+        expected = [key[6:] for key in style_file.keys() if key.startswith('style.')]
         assert test_unit.available_styles() == expected
-        for key in case.keys():
+        for key in style_file.keys():
             if key.startswith('style.'):
-                assert test_unit.get_style(key[6:]) == case[key]['rules'].split(',')
+                assert test_unit.get_style(key[6:]) == style_file[key]['rules'].split(',')
 
     def test_empty_file(self) -> None:
         test_unit = Configuration({})
@@ -60,25 +75,50 @@ class TestConfiguration():
         with raises(StylistException):
             _ = test_unit.get_style('empty-rules')
 
+    def test_parse_pipe(self, pipe_string) -> None:
+        stimulus, expected = pipe_string
+        if expected is not None:
+            extension, source, preproc = Configuration.parse_pipe_description(stimulus)
+            assert expected[0] == extension
+            assert expected[1] == source
+            assert expected[2] == preproc
+        else:
+            with raises(StylistException):
+                _ = Configuration.parse_pipe_description(stimulus)
+
+    def test_no_pipe(self) -> None:
+        test_unit = Configuration({})
+        assert [] == test_unit.get_file_pipes()
+
+    def test_get_pipe(self) -> None:
+        input = {'file-pipe': {'f90': 'fortran',
+                               'F90': 'fortran:fpp',
+                               'x90': 'fortran:pfp:fpp'}}
+        expected = [('f90', FortranSource, []),
+                    ('F90', FortranSource, [FortranPreProcessor]),
+                    ('x90', FortranSource, [PFUnitProcessor, FortranPreProcessor])]
+        test_unit = Configuration(input)
+        assert expected == list(test_unit.get_file_pipes())
+
 
 class TestFileConfiguration():
-    def test_file_configuration(self, tmp_path, case) -> None:
+    def test_file_configuration(self, tmp_path, style_file) -> None:
         config_file = tmp_path / 'test.ini'
         with config_file.open('w') as fhandle:
-            for section in case.keys():
+            for section in style_file.keys():
                 print(f'[{section}]', file=fhandle)
-                for key, value in case[section].items():
+                for key, value in style_file[section].items():
                     if isinstance(value, list):
                         print(f'  {key} = {", ".join(value)}', file=fhandle)
                     else:
                         print(f'  {key} = {value}', file=fhandle)
         test_unit = ConfigurationFile(config_file)
         assert test_unit.available_styles() \
-               == [key[6:] for key in case.keys()]
-        for key in case.keys():
+               == [key[6:] for key in style_file.keys()]
+        for key in style_file.keys():
             style_name = key[6:]
-            if 'rules' in case[key]:
-                assert test_unit.get_style(style_name) == case[key]['rules'].split(',')
+            if 'rules' in style_file[key]:
+                assert test_unit.get_style(style_name) == style_file[key]['rules'].split(',')
             else:
                 with raises(KeyError):
                     _ = test_unit.get_style(style_name)

--- a/unit-tests/configuration_test.py
+++ b/unit-tests/configuration_test.py
@@ -26,14 +26,22 @@ from stylist.source import (CPreProcessor,
 @fixture(scope='module',
          params=((None, None),
                  ('boo:fortran', ('boo', FortranSource, [])),
-                 ('coo:c:cpp',('coo', CSource, [CPreProcessor])),
-                 ('doo:fortran:pfp:fpp', ('doo', FortranSource, [PFUnitProcessor, FortranPreProcessor]))))
-def pipe_string(request: FixtureRequest) -> Tuple[str, Optional[Tuple[str, Type[SourceTree], Sequence[Type[TextProcessor]]]]]:
+                 ('coo:c:cpp', ('coo', CSource, [CPreProcessor])),
+                 ('doo:fortran:pfp:fpp', ('doo',
+                                          FortranSource,
+                                          [PFUnitProcessor,
+                                           FortranPreProcessor]))))
+def pipe_string(request: FixtureRequest) \
+    -> Tuple[str, Optional[Tuple[str,
+                                 Type[SourceTree],
+                                 Sequence[Type[TextProcessor]]]]]:
     return request.param
+
 
 @fixture(scope='module',
          params=({'style.only-rules': {'rules': 'foo-rule'}},
-                 {'style.only-multi-rules': {'rules': 'teapot-rule, cheese-rule'}},
+                 {'style.only-multi-rules': {'rules':
+                                             'teapot-rule, cheese-rule'}},
                  {'style.plus-rules': {'rules': 'bar-rule',
                                        'second': 'other thing'}}))
 def style_file(request: FixtureRequest) -> Mapping[str, Mapping[str, str]]:
@@ -43,11 +51,13 @@ def style_file(request: FixtureRequest) -> Mapping[str, Mapping[str, str]]:
 class TestConfiguration():
     def test_configuration(self, style_file) -> None:
         test_unit = Configuration(style_file)
-        expected = [key[6:] for key in style_file.keys() if key.startswith('style.')]
+        expected = [key[6:] for key in style_file.keys()
+                    if key.startswith('style.')]
         assert test_unit.available_styles() == expected
         for key in style_file.keys():
             if key.startswith('style.'):
-                assert test_unit.get_style(key[6:]) == style_file[key]['rules'].split(',')
+                assert test_unit.get_style(key[6:]) \
+                    == style_file[key]['rules'].split(',')
 
     def test_empty_file(self) -> None:
         test_unit = Configuration({})
@@ -78,7 +88,8 @@ class TestConfiguration():
     def test_parse_pipe(self, pipe_string) -> None:
         stimulus, expected = pipe_string
         if expected is not None:
-            extension, source, preproc = Configuration.parse_pipe_description(stimulus)
+            extension, source, preproc \
+                = Configuration.parse_pipe_description(stimulus)
             assert expected[0] == extension
             assert expected[1] == source
             assert expected[2] == preproc
@@ -96,7 +107,8 @@ class TestConfiguration():
                                'x90': 'fortran:pfp:fpp'}}
         expected = [('f90', FortranSource, []),
                     ('F90', FortranSource, [FortranPreProcessor]),
-                    ('x90', FortranSource, [PFUnitProcessor, FortranPreProcessor])]
+                    ('x90', FortranSource, [PFUnitProcessor,
+                                            FortranPreProcessor])]
         test_unit = Configuration(input)
         assert expected == list(test_unit.get_file_pipes())
 
@@ -114,11 +126,12 @@ class TestFileConfiguration():
                         print(f'  {key} = {value}', file=fhandle)
         test_unit = ConfigurationFile(config_file)
         assert test_unit.available_styles() \
-               == [key[6:] for key in style_file.keys()]
+            == [key[6:] for key in style_file.keys()]
         for key in style_file.keys():
             style_name = key[6:]
             if 'rules' in style_file[key]:
-                assert test_unit.get_style(style_name) == style_file[key]['rules'].split(',')
+                assert test_unit.get_style(style_name) \
+                       == style_file[key]['rules'].split(',')
             else:
                 with raises(KeyError):
                     _ = test_unit.get_style(style_name)

--- a/unit-tests/configuration_test.py
+++ b/unit-tests/configuration_test.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+##############################################################################
+# (c) Crown copyright 2020 Met Office. All rights reserved.
+# The file LICENCE, distributed with this code, contains details of the terms
+# under which the code may be used.
+##############################################################################
+"""Ensure the configuration module functions as expected."""
+from typing import Mapping
+from pytest import fixture  # type: ignore
+# ToDo: Obviously we shouldn't be importing "private" modules but until pytest
+#       sorts out its type hinting we are stuck with it.
+#
+from _pytest.fixtures import FixtureRequest  # type: ignore
+
+from stylist.configuration import ConfigurationFile, Configuration
+
+
+@fixture(scope='module',
+         params=({},
+                 {'empty-single': {}},
+                 {'skinny-single': {'only': 'thing'}},
+                 {'fulsome-single': {'first': 'thing',
+                                     'second': 'other thing'}},
+                 {'first-empty': {},
+                  'second-single': {'only': 'one'},
+                  'third-full': {'some': 'stuff',
+                                 'more': 'stuff'}}))
+def case(request: FixtureRequest) -> Mapping[str, Mapping[str, str]]:
+    return request.param
+
+
+class TestConfiguration():
+    def test_configuration(self, case) -> None:
+        test_unit = Configuration(case)
+        assert test_unit.section_names() == list(case.keys())
+        for key in case.keys():
+            assert test_unit.section(key) == case[key]
+
+    def test_sections_with_prefix(self, case) -> None:
+        test_unit = Configuration(case)
+        if 'second-single' in case.keys():
+            expected = ['second-single']
+        else:
+            expected = []
+        assert test_unit.section_names('second-') == expected
+
+
+class TestFileConfiguration():
+    def test_file_configuration(self, tmp_path, case) -> None:
+        config_file = tmp_path / 'test.ini'
+        with config_file.open('w') as fhandle:
+            for section in case.keys():
+                print(f'[{section}]', file=fhandle)
+                for key, value in case[section].items():
+                    print(f'  {key} = {value}', file=fhandle)
+        test_unit = ConfigurationFile(config_file)
+        assert test_unit.section_names() == list(case.keys())
+        for key in case.keys():
+            assert test_unit.section(key) == case[key]

--- a/unit-tests/source_test.py
+++ b/unit-tests/source_test.py
@@ -192,7 +192,7 @@ end program test
         expected_string = """! Test program
 PROGRAM test
   IMPLICIT NONE
-  WRITE(6, FMT = '("Hello ", A)') 'world'
+  WRITE(6, '("Hello ", A)') 'world'
 END PROGRAM test"""
         assert str(unit_under_test.get_tree()) == expected_string
 

--- a/unit-tests/style_test.py
+++ b/unit-tests/style_test.py
@@ -122,8 +122,7 @@ class TestDetermineStyle:
         """
         several_style_conf = Configuration(
             {'style.the_first': {'rules': '_RuleHarnessOne'},
-             'style.the_second': {'rules': ['_RuleHarnessOne',
-                                            '_RuleHarnessTwo(42)']},
+             'style.the_second': {'rules': '_RuleHarnessOne, _RuleHarnessTwo(42)'},
              'beef': {'whatsits': 'cheesy'},
              'style.the_third': {'rules': "_RuleHarnessTwo('super')"}})
         new_style = stylist.style.determine_style(several_style_conf,
@@ -137,8 +136,7 @@ class TestDetermineStyle:
         """
         single_style_conf = Configuration(
             {'cheese': {'thingy': 'thangy'},
-             'style.singular': {'rules': ['_RuleHarnessOne',
-                                          "_RuleHarnessTwo('blah')"]}})
+             'style.singular': {'rules': "_RuleHarnessOne, _RuleHarnessTwo('blah')"}})
         new_style = stylist.style.determine_style(single_style_conf,
                                                   'singular')
         assert new_style.list_rules() == ['_RuleHarnessOne',
@@ -150,8 +148,7 @@ class TestDetermineStyle:
         """
         single_style_conf = Configuration(
             {'cheese': {'thingy': 'thangy'},
-             'style.maybe': {'rules': ['_RuleHarnessOne',
-                                       "_RuleHarnessTwo('blah')"]}})
+             'style.maybe': {'rules': "_RuleHarnessOne, _RuleHarnessTwo('blah')"}})
         new_style = stylist.style.determine_style(single_style_conf)
         assert new_style.list_rules() == ['_RuleHarnessOne', '_RuleHarnessTwo']
 

--- a/unit-tests/style_test.py
+++ b/unit-tests/style_test.py
@@ -122,7 +122,8 @@ class TestDetermineStyle:
         """
         several_style_conf = Configuration(
             {'style.the_first': {'rules': '_RuleHarnessOne'},
-             'style.the_second': {'rules': '_RuleHarnessOne, _RuleHarnessTwo(42)'},
+             'style.the_second': {'rules':
+                                  '_RuleHarnessOne, _RuleHarnessTwo(42)'},
              'beef': {'whatsits': 'cheesy'},
              'style.the_third': {'rules': "_RuleHarnessTwo('super')"}})
         new_style = stylist.style.determine_style(several_style_conf,
@@ -136,7 +137,8 @@ class TestDetermineStyle:
         """
         single_style_conf = Configuration(
             {'cheese': {'thingy': 'thangy'},
-             'style.singular': {'rules': "_RuleHarnessOne, _RuleHarnessTwo('blah')"}})
+             'style.singular': {'rules':
+                                "_RuleHarnessOne, _RuleHarnessTwo('blah')"}})
         new_style = stylist.style.determine_style(single_style_conf,
                                                   'singular')
         assert new_style.list_rules() == ['_RuleHarnessOne',
@@ -148,7 +150,8 @@ class TestDetermineStyle:
         """
         single_style_conf = Configuration(
             {'cheese': {'thingy': 'thangy'},
-             'style.maybe': {'rules': "_RuleHarnessOne, _RuleHarnessTwo('blah')"}})
+             'style.maybe': {'rules':
+                             "_RuleHarnessOne, _RuleHarnessTwo('blah')"}})
         new_style = stylist.style.determine_style(single_style_conf)
         assert new_style.list_rules() == ['_RuleHarnessOne', '_RuleHarnessTwo']
 

--- a/unit-tests/style_test.py
+++ b/unit-tests/style_test.py
@@ -160,8 +160,7 @@ class TestDetermineStyle:
         Checks that an error is thrown if an attempt is made to load a default
         style from an empty style list.
         """
-        empty_conf = Configuration(
-            {'cheese': {'a': 42}})
+        empty_conf = Configuration({'cheese': {'a': '42'}})
         with pytest.raises(StylistException):
             stylist.style.determine_style(empty_conf)
 
@@ -172,8 +171,8 @@ class TestDetermineStyle:
         """
         several_style_conf = Configuration(
             {'style.the_first': {'rules': '_RuleHarnessOne'},
-             'style.the_second': {'rules': ['_RuleHarnessOne',
-                                            '_RuleHarnessTweo(42)']},
+             'style.the_second': {'rules':
+                                  '_RuleHarnessOne, _RuleHarnessTweo(42)'},
              'beef': {'whatsits': 'cheesy'},
              'style.the_third': {'rules': "_RuleHarnessTwo('super')"}})
         with pytest.raises(StylistException):


### PR DESCRIPTION
In order to make this a more generally useful tool the rules on handling different file extensions are moved into the configuration file.

Closes #9