### PR TITLE
Pass/Fail in verbose logging.

### DIFF
--- a/source/stylist/fortran.py
+++ b/source/stylist/fortran.py
@@ -22,8 +22,7 @@ class FortranRule(Rule, metaclass=ABCMeta):
     Parent for style rules pertaining to Fortran source.
     """
     def examine(self, subject: FortranSource) -> List[Issue]:
-        issues = super(FortranRule, self).examine(subject)
-
+        issues = []
         if not isinstance(subject, FortranSource):
             description = 'Non-Fortran source passed to a Fortran rule'
             raise Exception(description)
@@ -70,7 +69,7 @@ class FortranCharacterset(Rule):
         certain characters except comments and strings. These may contain
         anything.
         """
-        issues = super(FortranCharacterset, self).examine(subject)
+        issues = []
 
         text = subject.get_text()
         index = 0

--- a/source/stylist/rule.py
+++ b/source/stylist/rule.py
@@ -8,7 +8,6 @@
 None language specific rules.
 """
 from abc import ABCMeta, abstractmethod
-import logging
 import re
 from typing import List
 
@@ -30,9 +29,7 @@ class Rule(object, metaclass=ABCMeta):
         """
         Examines the provided source code object for an issue.
         """
-        message = 'Rule: {name}'.format(name=str(self.__class__.__name__))
-        logging.getLogger(__name__).info(message)
-        return []
+        raise NotImplementedError()
 
 
 class TrailingWhitespace(Rule):
@@ -46,8 +43,7 @@ class TrailingWhitespace(Rule):
         Examines the text for white space at the end of lines.
         This includes lines which consist entirely of white space.
         """
-        issues = super(TrailingWhitespace, self).examine(subject)
-
+        issues = []
         text = subject.get_text()
         line_tally = 0
         for line in text.splitlines():

--- a/source/stylist/style.py
+++ b/source/stylist/style.py
@@ -47,7 +47,7 @@ class Style(object, metaclass=ABCMeta):
         for rule in self._rules:
             additions = rule.examine(source)
             issues.extend(additions)
-            result = "Failed" if len(additions) > 0 else "Passed"
+            result = "Failed" if additions else "Passed"
             message = f"Rule: {rule.__class__.__name__} - {result}"
             logging.getLogger(__name__).info(message)
         return issues

--- a/source/stylist/style.py
+++ b/source/stylist/style.py
@@ -45,7 +45,11 @@ class Style(object, metaclass=ABCMeta):
         logging.getLogger(__name__).info('Style: ' + self.__class__.__name__)
         issues: List[stylist.issue.Issue] = []
         for rule in self._rules:
-            issues.extend(rule.examine(source))
+            additions = rule.examine(source)
+            issues.extend(additions)
+            result = "Failed" if len(additions) > 0 else "Passed"
+            message = f"Rule: {rule.__class__.__name__} - {result}"
+            logging.getLogger(__name__).info(message)
         return issues
 
 

--- a/source/stylist/style.py
+++ b/source/stylist/style.py
@@ -45,9 +45,9 @@ class Style(object, metaclass=ABCMeta):
         logging.getLogger(__name__).info('Style: ' + self.__class__.__name__)
         issues: List[stylist.issue.Issue] = []
         for rule in self._rules:
-            additions = rule.examine(source)
-            issues.extend(additions)
-            result = "Failed" if additions else "Passed"
+            additional_issues = rule.examine(source)
+            issues.extend(additional_issues)
+            result = "Failed" if additional_issues else "Passed"
             message = f"Rule: {rule.__class__.__name__} - {result}"
             logging.getLogger(__name__).info(message)
         return issues


### PR DESCRIPTION
This is a simple change which lifts the logging up a level in the call tree. This is probably a good change for a language like Python which requires the developer to remember to call parent constructors. In a language where that happens automatically it would be less of an issue.

Closes #15.