### PR TITLE
Kind pattern rule

### DIFF
--- a/source/stylist/fortran.py
+++ b/source/stylist/fortran.py
@@ -8,7 +8,9 @@
 Rules relating to Fortran source.
 """
 from abc import ABCMeta, abstractmethod
-from typing import Dict, List, Optional, Type
+from collections import defaultdict
+import re
+from typing import Dict, List, Optional, Pattern, Type, Union
 
 import fparser.two.Fortran2003 as Fortran2003  # type: ignore
 
@@ -292,6 +294,62 @@ class MissingPointerInit(FortranRule):
                         message \
                             = f"Unexpected source element: {repr(candidate)}"
                         raise Exception(message)
+
+        issues.sort(key=lambda x: (x.filename, x.line, x.description))
+        return issues
+
+
+class KindPattern(FortranRule):
+    def __init__(self,
+                 integer_pattern: Union[str, Pattern],
+                 real_pattern: Union[str, Pattern]):
+        self._patterns: Dict[str, Pattern] = defaultdict(lambda: re.compile(r'.*'))
+        if isinstance(integer_pattern, str):
+            self._patterns['integer'] = re.compile(integer_pattern)
+        else:
+            self._patterns['integer'] = integer_pattern
+        if isinstance(real_pattern, str):
+            self._patterns['real'] = re.compile(real_pattern)
+        else:
+            self._patterns['real'] = real_pattern
+
+    def examine_fortran(self, subject: FortranSource) -> List[Issue]:
+        issues: List[Issue] = []
+
+        candidates: List[Fortran2003.Base] = []
+        # Component variables
+        candidates.extend(
+            subject.find_all(Fortran2003.Data_Component_Def_Stmt))
+        # Component Procedure
+        candidates.extend(
+            subject.find_all(Fortran2003.Proc_Component_Def_Stmt))
+        # Procedure declaration
+        candidates.extend(
+            subject.find_all(Fortran2003.Procedure_Declaration_Stmt))
+        # Variable declaration
+        candidates.extend(
+            subject.find_all(Fortran2003.Type_Declaration_Stmt))
+
+        for candidate in candidates:
+            if isinstance(candidate,  # Is variable
+                          (Fortran2003.Data_Component_Def_Stmt,
+                           Fortran2003.Type_Declaration_Stmt)):
+                type_spec: Fortran2003.Intrinsic_Type_Spec = candidate.items[0]
+                kind_selector: Fortran2003.Kind_Selector = type_spec.items[1]
+                if isinstance(kind_selector, Fortran2003.Kind_Selector) and kind_selector is not None:
+                    data_type: str = type_spec.items[0].lower()
+                    kind: str = kind_selector.string[1:-1]
+                    match = self._patterns[data_type].match(kind)
+                    with open('debug.out', 'a') as handle:
+                        print(data_type, file=handle)
+                        print(kind, file=handle)
+                        print(self._patterns[data_type], file=handle)
+                        print(match, file=handle)
+                    if match is None:
+                        entity_declaration = candidate.items[2]
+                        message = f"Kind of variable '{entity_declaration}'" \
+                                  f" does not match pattern for {data_type.lower()} type."
+                        issues.append(Issue(message, line=candidate.item.span[0]))
 
         issues.sort(key=lambda x: (x.filename, x.line, x.description))
         return issues

--- a/source/stylist/style.py
+++ b/source/stylist/style.py
@@ -28,11 +28,11 @@ class Style(object, metaclass=ABCMeta):
             rules = [rules]
         self._rules = rules
 
-    def list_rules(self) -> List[str]:
+    def list_rules(self) -> List[stylist.rule.Rule]:
         """
         Gets a list of the rules which make up this style.
         """
-        return [rule.__class__.__name__ for rule in self._rules]
+        return self._rules
 
     def check(self,
               source: stylist.source.SourceTree) -> List[stylist.issue.Issue]:
@@ -101,7 +101,8 @@ def determine_style(configuration: Configuration,
         if rule_name not in potential_rules:
             raise StylistException(f"Unrecognised rule: {rule_name}")
         if rule_arguments:
-            rules.append(potential_rules[rule_name](*rule_arguments))
+            processed_args = [eval(arg) for arg in rule_arguments]
+            rules.append(potential_rules[rule_name](*processed_args))
         else:
             rules.append(potential_rules[rule_name]())
     return Style(rules)

--- a/system-tests/fortran/configuration.ini
+++ b/system-tests/fortran/configuration.ini
@@ -12,3 +12,6 @@ rules = MissingOnly
 
 [style.missing_pointer_init]
 rules = MissingPointerInit
+
+[style.wrong_kind]
+rules = KindPattern(r'.*_jazz', r'.*_metal')

--- a/system-tests/fortran/expected.wrong_kind.txt
+++ b/system-tests/fortran/expected.wrong_kind.txt
@@ -1,0 +1,7 @@
+stdout
+Found 4 issues
+stderr
+$$/wrong_kind.f90: 6: Kind of variable 'global_float' does not match pattern for real type.
+$$/wrong_kind.f90: 9: Kind of variable 'member_int' does not match pattern for integer type.
+$$/wrong_kind.f90: 19: Kind of variable 'arg_int' does not match pattern for integer type.
+$$/wrong_kind.f90: 26: Kind of variable 'marg_float' does not match pattern for real type.

--- a/system-tests/fortran/wrong_kind.f90
+++ b/system-tests/fortran/wrong_kind.f90
@@ -1,0 +1,29 @@
+program wrong_kind
+
+    implicit none
+
+    integer(trad_jazz) :: global_int
+    real(smooth_jazz) :: global_float
+
+    type test_type
+        integer(heavy_metal) :: member_int
+        real(speed_metal) :: member_float
+    contains
+        procedure method
+    end type test_type
+
+contains
+
+    function bad_int(arg_int, arg_float)
+        implicit none
+        integer(death_metal), intent(in) :: arg_int
+        real(glam_metal), intent(in) :: arg_float
+    end function bad_int
+
+    function method(this, marg_int, marg_float)
+        implicit none
+        integer(acid_jazz) :: marg_int
+        real(modern_jazz) :: marg_float
+    end function method
+
+end program wrong_kind

--- a/system-tests/fortran_rules_test.py
+++ b/system-tests/fortran_rules_test.py
@@ -22,7 +22,8 @@ class TestFortranRules(object):
     _RULES = ['bad_character',
               'missing_implicit',
               'missing_only',
-              'missing_pointer_init']
+              'missing_pointer_init',
+              'wrong_kind']
 
     @fixture(scope='class', params=_RULES)
     def rule(self, request: FixtureRequest) -> str:

--- a/unit-tests/fortran_kind_pattern_test.py
+++ b/unit-tests/fortran_kind_pattern_test.py
@@ -1,0 +1,145 @@
+##############################################################################
+# (c) Crown copyright 2021 Met Office. All rights reserved.
+# The file LICENCE, distributed with this code, contains details of the terms
+# under which the code may be used.
+##############################################################################
+"""
+Test of the rule for kind name pattern.
+"""
+import re
+from textwrap import dedent
+
+from stylist.fortran import KindPattern
+from stylist.source import FortranSource, SourceStringReader
+
+
+class TestKindPattern:
+    """
+    Test the checker of kind patterns.
+    """
+    def test_passing(self):
+        case = dedent("""
+        module passing_mod
+          implicit none
+          integer(medium_beef) :: global_int
+          integer(salt_beef) :: global_first, global_second
+          real(soft_cheese) :: global_float
+          logical(who_cares) :: global_bool
+          type some_type
+            integer(bloody_beef) :: member_int
+            integer(marbled_beef) :: member_int_1, member_int_2
+            real(blue_cheese) :: member_float
+            real(green_cheese) :: member_float_1, member_float_2
+            logical(no_difference) :: member_bool
+          contains
+            procedure method
+          end type some_type
+        contains
+          function thing(arg_int, arg_float, arg_float_1, arg_float_2, arg_bool) result(return_int)
+            implicit none
+            integer(rare_beef), intent(in) :: arg_int
+            real(hard_cheese), intent(out) :: arg_float
+            real(stinky_cheese), intent(in) :: arg_float_1, arg_float_2
+            logical(no_one_cares), intent(inout) :: arg_bool
+            integer(well_done_beef) :: return_int
+          end function thing
+          function method(this, marg_int, marg_int_1, marg_int_2, marg_float, marg_bool) result(return_float)
+            implicit none
+            integer(cremated_beef), intent(in) :: marg_int
+            integer(shredded_beef), intent(out) :: marg_int_1, marg_int_2
+            real(sheep_cheese), intent(out) :: marg_float
+            logical(sigh), intent(inout) :: marg_bool
+            real(goat_cheese) :: return_float
+          end function method
+        end module passing_mod
+        """)
+
+        reader = SourceStringReader(case)
+        source = FortranSource(reader)
+        unit_under_test = KindPattern(r'.+_beef', re.compile(r'.+_cheese'))
+        issues = unit_under_test.examine(source)
+
+        assert len(issues) == 0
+
+    def test_failing(self):
+        case = dedent("""
+        module passing_mod
+          implicit none
+          integer(soft_cheese) :: global_int
+          integer(blue_cheese) :: global_first, global_second
+          real(medium_beef) :: global_float
+          logical(who_cares) :: global_bool
+          type some_type
+            integer(green_cheese) :: member_int
+            integer(goat_cheese) :: member_int_1, member_int_2
+            real(salt_beef) :: member_float
+            real(bloody_beef) :: member_float_1, member_float_2
+            logical(no_difference) :: member_bool
+          contains
+            procedure method
+          end type some_type
+        contains
+          function thing(arg_int, arg_float, arg_bool) result(return_int)
+            implicit none
+            integer(hard_cheese), intent(in) :: arg_int
+            real(rare_beef), intent(out) :: arg_float
+            real(marbled_beef), intent(in) :: arg_float_1, arg_float_2
+            logical(no_one_cares), intent(inout) :: arg_bool
+            integer(stinky_cheese) :: return_int
+          end function thing
+          function method(this, marg_int, marg_float, marg_bool) result(return_float)
+            implicit none
+            integer(sheep_cheese), intent(in) :: marg_int
+            integer(chewy_cheese), intent(out) :: marg_int_1, marg_int_2
+            real(shredded_beef), intent(out) :: marg_float
+            logical(sigh), intent(inout) :: marg_bool
+            real(cremated_beef) :: return_float
+          end function method
+        end module passing_mod
+        """)
+
+        reader = SourceStringReader(case)
+        source = FortranSource(reader)
+        unit_under_test = KindPattern(r'.+_beef', re.compile(r'.+_cheese'))
+        issues = unit_under_test.examine(source)
+
+        assert len(issues) == 15
+
+    def test_missing_kind(self):
+        case = dedent("""
+        module passing_mod
+          implicit none
+          integer :: global_int
+          real :: global_float
+          logical :: global_bool
+          type some_type
+            integer :: member_int
+            real :: member_float
+            logical :: member_bool
+          contains
+            procedure method
+          end type some_type
+        contains
+          function thing(arg_int, arg_float, arg_bool) result(return_int)
+            implicit none
+            integer, intent(in) :: arg_int
+            real, intent(out) :: arg_float
+            logical, intent(inout) :: arg_bool
+            integer :: return_int
+          end function thing
+          function method(this, marg_int, marg_float, marg_bool) result(return_float)
+            implicit none
+            integer, intent(in) :: marg_int
+            real, intent(out) :: marg_float
+            logical, intent(inout) :: marg_bool
+            real :: return_float
+          end function method
+        end module passing_mod
+        """)
+
+        reader = SourceStringReader(case)
+        source = FortranSource(reader)
+        unit_under_test = KindPattern(r'.+_beef', re.compile(r'.+_cheese'))
+        issues = unit_under_test.examine(source)
+
+        assert len(issues) == 0

--- a/unit-tests/style_test.py
+++ b/unit-tests/style_test.py
@@ -79,7 +79,8 @@ class TestStyle(object):
         style.
         """
         unit_under_test = TestStyle._StyleHarness(initials[0])
-        assert unit_under_test.list_rules() == initials[1]
+        assert [rule.__class__.__name__
+                for rule in unit_under_test.list_rules()] == initials[1]
 
     class _RuleHarness(stylist.rule.Rule):
         def __init__(self):
@@ -128,8 +129,8 @@ class TestDetermineStyle:
              'style.the_third': {'rules': "_RuleHarnessTwo('super')"}})
         new_style = stylist.style.determine_style(several_style_conf,
                                                   'the_second')
-        assert new_style.list_rules() == ['_RuleHarnessOne',
-                                          '_RuleHarnessTwo']
+        assert [rule.__class__.__name__ for rule in new_style.list_rules()] \
+               == ['_RuleHarnessOne', '_RuleHarnessTwo']
 
     def test_single_style(self, tmp_path: Path):
         """
@@ -141,8 +142,8 @@ class TestDetermineStyle:
                                 "_RuleHarnessOne, _RuleHarnessTwo('blah')"}})
         new_style = stylist.style.determine_style(single_style_conf,
                                                   'singular')
-        assert new_style.list_rules() == ['_RuleHarnessOne',
-                                          '_RuleHarnessTwo']
+        assert [rule.__class__.__name__ for rule in new_style.list_rules()] \
+               == ['_RuleHarnessOne', '_RuleHarnessTwo']
 
     def test_default_style(self, tmp_path: Path):
         """
@@ -153,7 +154,8 @@ class TestDetermineStyle:
              'style.maybe': {'rules':
                              "_RuleHarnessOne, _RuleHarnessTwo('blah')"}})
         new_style = stylist.style.determine_style(single_style_conf)
-        assert new_style.list_rules() == ['_RuleHarnessOne', '_RuleHarnessTwo']
+        assert [rule.__class__.__name__ for rule in new_style.list_rules()] \
+               == ['_RuleHarnessOne', '_RuleHarnessTwo']
 
     def test_no_default(self, tmp_path: Path):
         """
@@ -172,8 +174,18 @@ class TestDetermineStyle:
         several_style_conf = Configuration(
             {'style.the_first': {'rules': '_RuleHarnessOne'},
              'style.the_second': {'rules':
-                                  '_RuleHarnessOne, _RuleHarnessTweo(42)'},
+                                  '_RuleHarnessOne, _RuleHarnessTwo(42)'},
              'beef': {'whatsits': 'cheesy'},
              'style.the_third': {'rules': "_RuleHarnessTwo('super')"}})
         with pytest.raises(StylistException):
             stylist.style.determine_style(several_style_conf)
+
+    def test_raw_argument(selfself, tmp_path: Path):
+        """
+        Checks that raw-string arguments arr handled correctly.
+        """
+        conf = Configuration({'style.rawarg': {'rules': "_RuleHarnessTwo(r'.*')"}})
+        style = stylist.style.determine_style(conf)
+        assert [rule.__class__.__name__ for rule in style.list_rules()] \
+               == ['_RuleHarnessTwo']
+        assert style.list_rules()[0].thing == r'.*'


### PR DESCRIPTION
Closes #26 by implementing a rule to test Fortran "kind"s against a regex pattern.

Only integer and real are covered at the moment. Others may be added as we need them.

This change also fixes a few shortcomings in the infrastructure discovered while developing this rule.

There is an open question about how to handle declarations without a kind. It could be covered by this rule or it could be the purview of a separate rule. At the moment this rule ignores declarations without a kind.