### PR TITLE
#28 Missing Intrinsic's

### DIFF
--- a/source/stylist/fortran.py
+++ b/source/stylist/fortran.py
@@ -203,6 +203,35 @@ class MissingOnly(FortranRule):
         return issues
 
 
+class IntrinsicModule(FortranRule):
+    """
+    Catches cases where an intrinsic module is used with the "intrinsic"
+    keyword ommitted.
+    """
+
+    def __init__(self):
+        """
+        Constructs an "IntrinsicModule" rule object.
+        """
+        self.intrinsics = ["iso_c_binding", "iso_fortran_env",
+                           "ieee_exceptions", "ieee_arithmetic",
+                           "ieee_features"]
+
+    def examine_fortran(self, subject: FortranSource) -> List[Issue]:
+        issues = []
+        for statement in subject.find_all(Fortran2003.Use_Stmt):
+            module = statement.items[2]
+            if str(module).lower() in self.intrinsics:
+                nature = statement.items[0]
+                if nature is None or nature.string.lower() != 'intrinsic':
+                    description = 'Usage of intrinsic module "{module}" ' \
+                                  'without "intrinsic" clause.'
+                    issues.append(Issue(description.format(module=module),
+                                        line=statement.item.span[0]))
+
+        return issues
+
+
 class LabelledExit(FortranRule):
     """
     Catches cases where a "do" construct is exited but not explicitly named.

--- a/source/stylist/fortran.py
+++ b/source/stylist/fortran.py
@@ -209,20 +209,15 @@ class IntrinsicModule(FortranRule):
     Catches cases where an intrinsic module is used with the "intrinsic"
     keyword ommitted.
     """
-
-    def __init__(self):
-        """
-        Constructs an "IntrinsicModule" rule object.
-        """
-        self.intrinsics = ["iso_c_binding", "iso_fortran_env",
-                           "ieee_exceptions", "ieee_arithmetic",
-                           "ieee_features"]
+    _INTRINSICS = ["iso_c_binding", "iso_fortran_env",
+                   "ieee_exceptions", "ieee_arithmetic",
+                   "ieee_features"]
 
     def examine_fortran(self, subject: FortranSource) -> List[Issue]:
         issues = []
         for statement in subject.find_all(Fortran2003.Use_Stmt):
             module = statement.items[2]
-            if str(module).lower() in self.intrinsics:
+            if str(module).lower() in self._INTRINSICS:
                 nature = statement.items[0]
                 if nature is None or nature.string.lower() != 'intrinsic':
                     description = 'Usage of intrinsic module "{module}" ' \

--- a/system-tests/fortran/configuration.ini
+++ b/system-tests/fortran/configuration.ini
@@ -19,5 +19,8 @@ rules = KindPattern(integer=r'.*_jazz', real=r'.*_metal')
 [style.labelled_exit]
 rules = LabelledExit
 
+[style.intrinsic_module]
+rules = IntrinsicModule
+
 [style.multiple]
 rules = FortranCharacterset, MissingImplicit(require_everywhere=True), MissingPointerInit

--- a/system-tests/fortran/expected.intrinsic_module.txt
+++ b/system-tests/fortran/expected.intrinsic_module.txt
@@ -1,8 +1,13 @@
 stdout
-Found 5 issues
+Found 10 issues
 stderr
 $$/intrinsic_module.f90: 2: Usage of intrinsic module "iso_c_binding" without "intrinsic" clause.
-$$/intrinsic_module.f90: 3: Usage of intrinsic module "iso_fortran_env" without "intrinsic" clause.
 $$/intrinsic_module.f90: 4: Usage of intrinsic module "ieee_exceptions" without "intrinsic" clause.
 $$/intrinsic_module.f90: 5: Usage of intrinsic module "ieee_arithmetic" without "intrinsic" clause.
-$$/intrinsic_module.f90: 6: Usage of intrinsic module "ieee_features" without "intrinsic" clause.
+$$/intrinsic_module.f90: 12: Usage of intrinsic module "ISO_Fortran_env" without "intrinsic" clause.
+$$/intrinsic_module.f90: 15: Usage of intrinsic module "ieee_features" without "intrinsic" clause.
+$$/intrinsic_module.f90: 20: Usage of intrinsic module "iso_c_binding" without "intrinsic" clause.
+$$/intrinsic_module.f90: 22: Usage of intrinsic module "ieee_exceptions" without "intrinsic" clause.
+$$/intrinsic_module.f90: 23: Usage of intrinsic module "ieee_arithmetic" without "intrinsic" clause.
+$$/intrinsic_module.f90: 31: Usage of intrinsic module "ISO_Fortran_env" without "intrinsic" clause.
+$$/intrinsic_module.f90: 34: Usage of intrinsic module "ieee_features" without "intrinsic" clause.

--- a/system-tests/fortran/expected.intrinsic_module.txt
+++ b/system-tests/fortran/expected.intrinsic_module.txt
@@ -1,0 +1,8 @@
+stdout
+Found 5 issues
+stderr
+$$/intrinsic_module.f90: 2: Usage of intrinsic module "iso_c_binding" without "intrinsic" clause.
+$$/intrinsic_module.f90: 3: Usage of intrinsic module "iso_fortran_env" without "intrinsic" clause.
+$$/intrinsic_module.f90: 4: Usage of intrinsic module "ieee_exceptions" without "intrinsic" clause.
+$$/intrinsic_module.f90: 5: Usage of intrinsic module "ieee_arithmetic" without "intrinsic" clause.
+$$/intrinsic_module.f90: 6: Usage of intrinsic module "ieee_features" without "intrinsic" clause.

--- a/system-tests/fortran/intrinsic_module.f90
+++ b/system-tests/fortran/intrinsic_module.f90
@@ -1,17 +1,36 @@
-program bad_program
+program a_program
     use iso_c_binding
-    use iso_fortran_env
+    use, intrinsic :: iso_fortran_env
     use ieee_exceptions
     use ieee_arithmetic
+    use, intrinsic :: ieee_features
+    use some_module
+end program a_program
+
+module a_module
+    use, intrinsic :: iso_c_binding
+    use ISO_Fortran_env
+    use, intrinsic :: ieee_exceptions
+    use, intrinsic :: ieee_arithmetic
     use ieee_features
     use some_module
-end program bad_program
+end module a_module
 
-module good_module
+function a_function(x)
+    use iso_c_binding
+    use, intrinsic :: iso_fortran_env
+    use ieee_exceptions
+    use ieee_arithmetic
+    use, intrinsic :: ieee_features
+    use some_module
+    integer, intent(inout) :: x = 2
+end function
+
+subroutine a_subroutine
     use, intrinsic :: iso_c_binding
-    use, intrinsic :: iso_c_binding
-    use, intrinsic :: ISO_Fortran_env
+    use ISO_Fortran_env
     use, intrinsic :: ieee_exceptions
-    use, intrinsic ::  ieee_arithmetic
-    use, intrinsic ::  ieee_features
-end module good_module
+    use, intrinsic :: ieee_arithmetic
+    use ieee_features
+    use some_module
+end subroutine

--- a/system-tests/fortran/intrinsic_module.f90
+++ b/system-tests/fortran/intrinsic_module.f90
@@ -1,0 +1,17 @@
+program bad_program
+    use iso_c_binding
+    use iso_fortran_env
+    use ieee_exceptions
+    use ieee_arithmetic
+    use ieee_features
+    use some_module
+end program bad_program
+
+module good_module
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: ISO_Fortran_env
+    use, intrinsic :: ieee_exceptions
+    use, intrinsic ::  ieee_arithmetic
+    use, intrinsic ::  ieee_features
+end module good_module

--- a/unit-tests/fortran_intrinsic_module_test.py
+++ b/unit-tests/fortran_intrinsic_module_test.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+##############################################################################
+# (c) Crown copyright 2018 Met Office. All rights reserved.
+# The file LICENCE, distributed with this code, contains details of the terms
+# under which the code may be used.
+##############################################################################
+"""
+Test of the rule for missing exit labels.
+"""
+from typing import List
+
+import pytest  # type: ignore
+from _pytest.fixtures import FixtureRequest  # type: ignore
+
+from stylist.fortran import IntrinsicModule
+from stylist.source import FortranSource, SourceStringReader
+
+
+# ToDo: Obviously we shouldn't be importing "private" modules but until pytest
+#       sorts out its type hinting we are stuck with it.
+
+
+class TestIntrinsicModule(object):
+    """
+    Tests the checker of missing exit labels.
+    """
+
+    @pytest.fixture(scope='class',
+                    params=["iso_c_binding", "ISO_Fortran_env",
+                            "ieee_exceptions", "ieee_arithmetic",
+                            "ieee_features", "other_module"])
+    def module_name(self, request: FixtureRequest) -> str:
+        """
+        Parameter fixture giving module names
+        """
+        return request.param
+
+    def test_exit_labels(self,
+                         module_name: str) -> None:
+        """
+        Checks that the rule reports missing "implicit" labels correctly
+        """
+        template = '''
+program test
+contains
+    function function1()
+        use {module_name}
+    end function function1
+
+    function function2()
+        use, intrinsic :: {module_name}
+    end function function2
+end program test
+'''
+
+        expectation: List[str] = []
+        message = '{line}: Usage of intrinsic module "{module_name}" without '\
+                  '"intrinsic" clause.'
+        if module_name.lower() in ["iso_c_binding", "iso_fortran_env",
+                                   "ieee_exceptions", "ieee_arithmetic",
+                                   "ieee_features"]:
+            expectation.extend([
+                message.format(line=5, module_name=module_name),
+            ])
+        text = template.format(
+            module_name=module_name)
+        print(text)  # Shows up in failure reports, for debugging
+        reader = SourceStringReader(text)
+        source = FortranSource(reader)
+        unit_under_test = IntrinsicModule()
+        issues = unit_under_test.examine(source)
+        issue_descriptions = [str(issue) for issue in issues]
+        assert issue_descriptions == expectation


### PR DESCRIPTION
Adds rule to ensure when each of the five fortran intrinsic modules is used the `intrinsic` keyword must also be used. Some online sources reference being able to use the keyword `non_intrinsic` otherwise, but this seems to be non standard. At present there is no ability to ignore this style on an individual basis, if I wanted to use my own `IEEE_Features` module say, though this could be implemented in a pylint sort of fashion with a comment like  `# stylist : ignore IntrinsicModule` proceeding the use statement. Any other ideas? Closes #28.