### PR TITLE
Forbid module usage

### DIFF
--- a/system-tests/fortran/configuration.ini
+++ b/system-tests/fortran/configuration.ini
@@ -28,5 +28,8 @@ rules = IntrinsicModule
 [style.auto_char_array_intent]
 rules = AutoCharArrayIntent
 
+[style.forbid_usage]
+rules = ForbidUsage('fat_bank', ('boss', 'contractor_mod', 'share_holder'))
+
 [style.multiple]
 rules = FortranCharacterset, MissingImplicit(require_everywhere=True), MissingPointerInit

--- a/system-tests/fortran/expected.forbid_usage.txt
+++ b/system-tests/fortran/expected.forbid_usage.txt
@@ -1,0 +1,5 @@
+stdout
+Found 1 issue
+stderr
+$$/forbid_usage.f90: 6: Attempt to use forbidden module 'fat_bank'
+

--- a/system-tests/fortran/forbid_usage.f90
+++ b/system-tests/fortran/forbid_usage.f90
@@ -1,0 +1,15 @@
+program boss
+    use fat_bank
+end program boss
+
+module worker_mod
+    use fat_bank
+end module worker_mod
+
+module contractor_mod
+    use fat_bank
+end module contractor_mod
+
+module share_holder
+    use fat_bank
+end module share_holder

--- a/unit-tests/configuration_test.py
+++ b/unit-tests/configuration_test.py
@@ -7,6 +7,7 @@
 """Ensure the configuration module functions as expected."""
 import re
 from typing import Mapping, Optional, Sequence, Tuple, Type
+
 from pytest import fixture, raises  # type: ignore
 # ToDo: Obviously we shouldn't be importing "private" modules but until pytest
 #       sorts out its type hinting we are stuck with it.

--- a/unit-tests/fortran_forbid_usage_test.py
+++ b/unit-tests/fortran_forbid_usage_test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+##############################################################################
+# (c) Crown copyright 2022 Met Office. All rights reserved.
+# The file LICENCE, distributed with this code, contains details of the terms
+# under which the code may be used.
+##############################################################################
+"""
+Test of the rule for missing exit labels.
+"""
+from textwrap import dedent
+
+from stylist.fortran import ForbidUsage
+from stylist.source import FortranSource, SourceStringReader
+
+
+# ToDo: Obviously we shouldn't be importing "private" modules but until pytest
+#       sorts out its type hinting we are stuck with it.
+
+
+class TestForbidUsage(object):
+    """
+    Tests the rule which forbids usage of certain modules.
+    """
+    def test_forbid_usage(self) -> None:
+        """
+        Checks that usage is forbidden.
+        """
+        source_text = dedent('''
+                             module some_mod
+                               use fish_mod, only: breem
+                               use beef_mod
+                               use alpha_mod, only: tiptop
+                             contains
+                               subroutine stuff()
+                                 use grief_mod, only: agro
+                                 use alpha_mod
+                                 use bingo_mod
+                               end subroutine stuff
+                             end module some_mod
+                             ''').strip()
+        reader = SourceStringReader(source_text)
+        source = FortranSource(reader)
+
+        test_unit = ForbidUsage('alpha_mod')
+        issues = test_unit.examine(source)
+
+        issue_descriptions = [str(issue) for issue in issues]
+        assert issue_descriptions == [
+            "4: Attempt to use forbidden module 'alpha_mod'",
+            "8: Attempt to use forbidden module 'alpha_mod'"
+        ]
+
+    def test_except_usage(self) -> None:
+        """
+        Check that exceptions work.
+        """
+        source_text = dedent('''
+                             module teapot_mod
+                               use fish_mod, only: breem
+                               use beef_mod
+                               use ceramic_mod, only: tiptop
+                             contains
+                               subroutine stuff()
+                                 use grief_mod, only: agro
+                                 use ceramic_mod
+                                 use bingo_mod
+                               end subroutine stuff
+                             end module teapot_mod
+                             module plate_mod
+                               use ceramtic_mod
+                             contains
+                               subroutine nonsense()
+                                 use ceramic_mod, only: toptip
+                               end subroutine nonsense
+                             end module plate_mod
+                             module fork_mod
+                               use ceramic_mod, only: specialist
+                             contains
+                               subroutine piffle()
+                                 use ceramic_mod
+                               end subroutine piffle
+                             end module fork_mod
+                             ''').strip()
+        reader = SourceStringReader(source_text)
+        source = FortranSource(reader)
+
+        test_unit = ForbidUsage('ceramic_mod', ['teapot_mod', 'plate_mod'])
+        issues = test_unit.examine(source)
+
+        issue_descriptions = [str(issue) for issue in issues]
+        assert issue_descriptions == [
+            "20: Attempt to use forbidden module 'ceramic_mod'",
+            "23: Attempt to use forbidden module 'ceramic_mod'"
+        ]

--- a/unit-tests/fortran_missing_intent_test.py
+++ b/unit-tests/fortran_missing_intent_test.py
@@ -29,7 +29,7 @@ from stylist.source import FortranSource, SourceStringReader
                             contains
                             {procedure}
                             end module test_module''',
-                        '''! move to third line to save calculating line numbers
+                        '''! pad to third line to match line numbers
                            !
                            {procedure}'''])
 def parent_container(request: FixtureRequest) -> str:

--- a/unit-tests/style_test.py
+++ b/unit-tests/style_test.py
@@ -45,6 +45,19 @@ class _RuleHarnessTwo(stylist.rule.Rule):
         pass
 
 
+class _RuleHarnessThree(stylist.rule.Rule):
+    """
+    Completely empty but concrete implementation of a rule. This one has a
+    constructor with two arguments.
+    """
+    def __init__(self, thing, other_thing):
+        self.thing = thing
+        self.other_thing = other_thing
+
+    def examine(self, subject):
+        pass
+
+
 class TestStyle(object):
     """
     Tests the abstract TestStyle class.
@@ -214,3 +227,20 @@ class TestDetermineStyle:
         assert len(rules) == 1
         assert isinstance(rules[0], _RuleHarnessTwo)
         assert cast(_RuleHarnessTwo, rules[0]).thing == 'bing'
+
+    def test_collection_argument(self) -> None:
+        """
+        Checks that collection arguments are handled correctly.
+        """
+        initialiser = {'style.colarg':
+                       {'rules': "_RuleHarnessThree('arg1', "
+                           "('tup1', 'tup2'))"}}
+        conf = Configuration(initialiser)
+        style = stylist.style.determine_style(conf)
+
+        rules = style.list_rules()
+        assert len(rules) == 1
+        assert isinstance(rules[0], _RuleHarnessThree)
+        assert cast(_RuleHarnessThree, rules[0]).thing == 'arg1'
+        assert cast(_RuleHarnessThree, rules[0]).other_thing == ('tup1',
+                                                                 'tup2')


### PR DESCRIPTION
There are some modules which should not be used outside controlled circumstances. This rule detects module usage outside an exception list.

Closes #63 