### PR TITLE
Constrain fParser version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     package_dir={'': 'source'},
     packages=find_packages(where='source'),
     python_requires='>=3.7, <4',
-    install_requires=['fparser >= 0.0.12'],
+    install_requires=['fparser >= 0.0.12, < 0.1.0'],
     extras_require={
         'dev': ['check-manifest', 'flake8', 'mypy'],
         'test': ['pytest', 'pytest-cov'],


### PR DESCRIPTION
The recently released fParser v0.1.0 causes problems with our testing. Until someone has time to look at the testing we should constrain the fParser version.