### PR TITLE
Improve CLI handling of configuration file arguments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ below:
 * Matt Shin (Met Office, UK)
 * Bilal Chughtai (Met Office, UK)
 * James Cuninngham-Smith (Met Office, UK)
+* Sam Clarke-Green (Met Office, UK)
 
 (All contributors are identifiable with email addresses in the version control
 logs or otherwise.)

--- a/source/stylist/__main__.py
+++ b/source/stylist/__main__.py
@@ -81,6 +81,12 @@ IDs used in specifying extension pipelines:
 
     arguments = cli_parser.parse_args()
 
+    if not arguments.configuration.exists():
+        cli_parser.error("configuration file does not exist")
+
+    if arguments.configuration.suffix not in (".py", ".pyc"):
+        cli_parser.error("configuration must be a python file")
+
     return arguments
 
 

--- a/source/stylist/__main__.py
+++ b/source/stylist/__main__.py
@@ -13,7 +13,7 @@ from os import linesep
 from pathlib import Path
 import sys
 from textwrap import indent
-from typing import List, Sequence
+from typing import List, Sequence, Union
 
 from stylist import StylistException
 from stylist.configuration import (Configuration,
@@ -112,7 +112,7 @@ def __process(candidates: List[Path], styles: Sequence[Style]) -> List[Issue]:
     return issues
 
 
-def __configure(project_file: Path) -> Configuration:
+def __configure(project_file: Path) -> Union[Configuration, None]:
     """
     Load configuration styles in order of specificity
 

--- a/source/stylist/__main__.py
+++ b/source/stylist/__main__.py
@@ -59,6 +59,7 @@ IDs used in specifying extension pipelines:
                             help="Produce a running commentary on progress.")
     cli_parser.add_argument('-configuration',
                             type=Path,
+                            required=True,
                             metavar='FILENAME',
                             help="File which configures the tool.")
     message = "Style to use for check. May be specified repeatedly."

--- a/source/stylist/configuration.py
+++ b/source/stylist/configuration.py
@@ -9,6 +9,8 @@ Handles configuration parameters coming from various potential sources.
 
 Configuration may be defined by software or read from a Windows .ini file.
 """
+from __future__ import annotations
+
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from typing import Dict, List, Tuple, Type
@@ -36,6 +38,10 @@ class Configuration:
 
     def add_style(self, name: str, style: Style):
         self._styles[name] = style
+
+    def overload(self, other: Configuration) -> None:
+        self._pipes = {**self._pipes, **other._pipes}
+        self._styles = {**self._styles, **other._styles}
 
     @property
     def file_pipes(self) -> Dict[str, FilePipe]:


### PR DESCRIPTION
A combination of issues #129 and #130, this makes the `-configuration` command line argument compulsory, checks that that file passed as an argument exists, and confirms that the suffix matches a valid python file.  This allows the CLI's ArgumentParser to return an error to the user fairly early on, rather than allowing a StylistException to propagate to the top level as happened previously.