### PR TITLE
Made values dynamic in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = '>=3.7, <4'
 license = {text = 'BSD 3-Clause License'}
 classifiers = ['Programming Language :: Python :: 3']
 dependencies = ['fparser >= 0.1.2']
-dynamic = ['version', 'authors', 'keywords', 'readme']
+dynamic = ['version', 'readme']
 
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = '>=3.7, <4'
 license = {text = 'BSD 3-Clause License'}
 classifiers = ['Programming Language :: Python :: 3']
 dependencies = ['fparser >= 0.1.2']
-dynamic = ['version']
+dynamic = ['version', 'authors', 'keywords', 'readme']
 
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes issue #134 

When trying to install stylist, pip was throwing errors because certain values weren’t listed as “dynamic” in the pyproject.toml file. Adding the values in question to the dynamic setting fixed the issue.

To reproduce the error you can run the following command inside your stylist repo.
`pip install . `

The error messages were all like so:

```
According to the spec (see the link below), however, setuptools CANNOT consider this value unless "readme" is listed as "dynamic".
https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
To prevent this problem, you can list "readme" under "dynamic" or alternatively remove the "[project]" table from your file and rely entirely on other means of configuration.

```