### PR TITLE
Updated Python versions to test with.

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.7, 3.8, "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
We were testing against some old versions which have gone end-of-life and are no longer available to GitHub workflows. We were also not testing on newer versions.